### PR TITLE
카카오 계정 연동 해지 기능 구현

### DIFF
--- a/src/main/java/com/alzzaipo/member/adapter/in/web/OAuthController.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/OAuthController.java
@@ -1,17 +1,17 @@
 package com.alzzaipo.member.adapter.in.web;
 
+import com.alzzaipo.common.LoginType;
 import com.alzzaipo.common.MemberPrincipal;
+import com.alzzaipo.member.application.port.in.account.social.UnlinkSocialAccountUseCase;
 import com.alzzaipo.member.application.port.in.dto.AuthorizationCode;
 import com.alzzaipo.member.application.port.in.dto.LoginResult;
+import com.alzzaipo.member.application.port.in.dto.UnlinkSocialAccountCommand;
 import com.alzzaipo.member.application.port.in.oauth.KakaoLoginUseCase;
 import com.alzzaipo.member.application.port.in.oauth.LinkKakaoAccountUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/oauth")
@@ -20,6 +20,7 @@ public class OAuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
     private final LinkKakaoAccountUseCase linkKakaoAccountUseCase;
+    private final UnlinkSocialAccountUseCase unlinkSocialAccountUseCase;
 
     @GetMapping("/kakao/login")
     public ResponseEntity<String> kakaoLogin(@RequestParam("code") String authCode) {
@@ -45,5 +46,16 @@ public class OAuthController {
                 new AuthorizationCode(authCode));
 
         return ResponseEntity.ok().body("연동 완료");
+    }
+
+    @DeleteMapping("/kakao/unlink")
+    public ResponseEntity<String> kakaoUnlink(@AuthenticationPrincipal MemberPrincipal principal) {
+        UnlinkSocialAccountCommand command = new UnlinkSocialAccountCommand(
+                principal.getMemberUID(),
+                LoginType.KAKAO);
+
+        unlinkSocialAccountUseCase.unlinkSocialAccountUseCase(command);
+
+        return ResponseEntity.ok().body("해지 완료");
     }
 }

--- a/src/main/java/com/alzzaipo/member/application/port/in/account/social/UnlinkSocialAccountUseCase.java
+++ b/src/main/java/com/alzzaipo/member/application/port/in/account/social/UnlinkSocialAccountUseCase.java
@@ -1,0 +1,8 @@
+package com.alzzaipo.member.application.port.in.account.social;
+
+import com.alzzaipo.member.application.port.in.dto.UnlinkSocialAccountCommand;
+
+public interface UnlinkSocialAccountUseCase {
+
+    void unlinkSocialAccountUseCase(UnlinkSocialAccountCommand command);
+}

--- a/src/main/java/com/alzzaipo/member/application/port/in/dto/UnlinkSocialAccountCommand.java
+++ b/src/main/java/com/alzzaipo/member/application/port/in/dto/UnlinkSocialAccountCommand.java
@@ -1,0 +1,17 @@
+package com.alzzaipo.member.application.port.in.dto;
+
+import com.alzzaipo.common.LoginType;
+import com.alzzaipo.common.Uid;
+import lombok.Getter;
+
+@Getter
+public class UnlinkSocialAccountCommand {
+
+    private final Uid memberUID;
+    private final LoginType loginType;
+
+    public UnlinkSocialAccountCommand(Uid memberUID, LoginType loginType) {
+        this.memberUID = memberUID;
+        this.loginType = loginType;
+    }
+}

--- a/src/main/java/com/alzzaipo/member/application/port/out/account/social/DeleteSocialAccountPort.java
+++ b/src/main/java/com/alzzaipo/member/application/port/out/account/social/DeleteSocialAccountPort.java
@@ -1,0 +1,9 @@
+package com.alzzaipo.member.application.port.out.account.social;
+
+import com.alzzaipo.common.LoginType;
+import com.alzzaipo.common.Uid;
+
+public interface DeleteSocialAccountPort {
+
+    void deleteSocialAccount(Uid memberUID, LoginType loginType);
+}

--- a/src/main/java/com/alzzaipo/member/application/service/account/social/UnlinkSocialAccountService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/account/social/UnlinkSocialAccountService.java
@@ -1,0 +1,28 @@
+package com.alzzaipo.member.application.service.account.social;
+
+import com.alzzaipo.common.exception.CustomException;
+import com.alzzaipo.member.application.port.in.account.social.UnlinkSocialAccountUseCase;
+import com.alzzaipo.member.application.port.in.dto.UnlinkSocialAccountCommand;
+import com.alzzaipo.member.application.port.out.account.local.FindLocalAccountByMemberUidPort;
+import com.alzzaipo.member.application.port.out.account.social.DeleteSocialAccountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UnlinkSocialAccountService implements UnlinkSocialAccountUseCase {
+
+    private final FindLocalAccountByMemberUidPort findLocalAccountByMemberUidPort;
+    private final DeleteSocialAccountPort deleteSocialAccountUsePort;
+
+    @Override
+    public void unlinkSocialAccountUseCase(UnlinkSocialAccountCommand command) {
+        findLocalAccountByMemberUidPort.findLocalAccountByMemberUid(command.getMemberUID())
+                .orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "소셜 계정 연동 해지는 로컬 계정에서만 가능합니다."));
+
+        deleteSocialAccountUsePort.deleteSocialAccount(
+                command.getMemberUID(),
+                command.getLoginType());
+    }
+}


### PR DESCRIPTION
### 작업 사항

- 소셜 계정 연동 해지 기능 구현
- 카카오 계정 연동 해지 웹 API 구현 : `DELETE /oauth/kakao/unlink`