### PR TITLE
카카오 소셜 로그인 문제 해결

### DIFF
--- a/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
@@ -50,12 +50,15 @@ public class SecurityConfig {
                                 "/member/verify-email",
                                 "/member/register",
                                 "/member/login",
-                                "/**"
+                                "/ipo/**",
+                                "/email/**",
+                                "/scraper",
+                                "/oauth/kakao/login"
                         ).permitAll()
                         .requestMatchers(
                                 "/portfolio/**",
                                 "/member/**",
-                                "/social/kakao/connect",
+                                "/oauth/kakao/*",
                                 "/notification/**"
                         ).authenticated()
                 )
@@ -76,6 +79,7 @@ public class SecurityConfig {
                 "/member/login",
                 "/ipo/**",
                 "/email/**",
-                "/scraper");
+                "/scraper",
+                "/oauth/kakao/login");
     }
 }


### PR DESCRIPTION
필터 미적용 URL 목록에 '/oauth/kakao/login' 추가