### PR TITLE
회원 엔티티 유효성 검증 코드 중복 제거

### DIFF
--- a/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.alzzaipo.common.config;
 
 import com.alzzaipo.common.jwt.JwtFilter;
-import com.alzzaipo.common.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,15 +15,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 public class SecurityConfig {
 
-    private final JwtUtil jwtUtil;
+	private final JwtFilter jwtFilter;
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity
-            .csrf(AbstractHttpConfigurer::disable)
-            .cors().and()
-            .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors().and()
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return httpSecurity.build();
-    }
+		return httpSecurity.build();
+	}
 }

--- a/src/main/java/com/alzzaipo/common/jwt/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtFilter.java
@@ -1,6 +1,9 @@
 package com.alzzaipo.common.jwt;
 
 import com.alzzaipo.common.MemberPrincipal;
+import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.exception.CustomException;
+import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
@@ -13,79 +16,89 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    private final JwtUtil jwtUtil;
+	private final JwtUtil jwtUtil;
+	private final MemberRepository memberRepository;
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain)
-        throws IOException, ServletException {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain)
+		throws IOException, ServletException {
 
-        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 누락");
-            return;
-        }
+		if (authorization == null || !authorization.startsWith("Bearer ")) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 누락");
+			return;
+		}
 
-        String token = authorization.split(" ")[1];
+		String token = authorization.split(" ")[1];
 
-        try {
-            MemberPrincipal memberPrincipal = createPrincipalFromToken(token);
+		try {
+			MemberPrincipal memberPrincipal = createPrincipalFromToken(token);
 
-            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                memberPrincipal,
-                null,
-                List.of(new SimpleGrantedAuthority("USER")));
+			validateMemberUid(memberPrincipal.getMemberUID());
 
-            authenticationToken.setDetails(
-                new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-        } catch (ExpiredJwtException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 만료");
-            return;
-        } catch (SignatureException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 검증 실패");
-            return;
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "토큰 오류");
-            return;
-        }
+			UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+				memberPrincipal,
+				null,
+				List.of(new SimpleGrantedAuthority("USER")));
 
-        filterChain.doFilter(request, response);
-    }
+			authenticationToken.setDetails(
+				new WebAuthenticationDetailsSource().buildDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+		} catch (ExpiredJwtException e) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 만료");
+			return;
+		} catch (SignatureException e) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 검증 실패");
+			return;
+		} catch (Exception e) {
+			logger.error(e.getMessage());
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "토큰 오류");
+			return;
+		}
 
-    private MemberPrincipal createPrincipalFromToken(String token) {
-        return new MemberPrincipal(
-            jwtUtil.getMemberUID(token),
-            jwtUtil.getLoginType(token));
-    }
+		filterChain.doFilter(request, response);
+	}
 
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        List<String> excludePath = Arrays.asList(
-            "/member/verify-account-id",
-            "/member/verify-email",
-            "/member/register",
-            "/member/login",
-            "/ipo",
-            "/email",
-            "/scraper",
-            "/oauth/kakao/login");
+	private MemberPrincipal createPrincipalFromToken(String token) {
+		return new MemberPrincipal(
+			jwtUtil.getMemberUID(token),
+			jwtUtil.getLoginType(token));
+	}
 
-        String path = request.getRequestURI();
+	private void validateMemberUid(Uid memberUID) {
+		memberRepository.findById(memberUID.get())
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	}
 
-        return excludePath.stream().anyMatch(path::startsWith);
-    }
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+		List<String> excludePath = Arrays.asList(
+			"/member/verify-account-id",
+			"/member/verify-email",
+			"/member/register",
+			"/member/login",
+			"/ipo",
+			"/email",
+			"/scraper",
+			"/oauth/kakao/login");
 
+		String path = request.getRequestURI();
+
+		return excludePath.stream().anyMatch(path::startsWith);
+	}
 }

--- a/src/main/java/com/alzzaipo/email/adapter/out/web/SendCustomEmailAdapter.java
+++ b/src/main/java/com/alzzaipo/email/adapter/out/web/SendCustomEmailAdapter.java
@@ -1,6 +1,6 @@
 package com.alzzaipo.email.adapter.out.web;
 
-import com.alzzaipo.email.application.port.in.SendCustomEmail;
+import com.alzzaipo.email.application.port.out.SendCustomEmail;
 import com.alzzaipo.common.Email;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/alzzaipo/email/application/port/out/SendCustomEmail.java
+++ b/src/main/java/com/alzzaipo/email/application/port/out/SendCustomEmail.java
@@ -1,4 +1,4 @@
-package com.alzzaipo.email.application.port.in;
+package com.alzzaipo.email.application.port.out;
 
 import com.alzzaipo.common.Email;
 

--- a/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIposService.java
+++ b/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIposService.java
@@ -1,4 +1,4 @@
-package com.alzzaipo.ipo.application.service;
+package com.alzzaipo.ipo.application.service.scheduled;
 
 import com.alzzaipo.ipo.application.port.out.FindNotListedIposPort;
 import com.alzzaipo.ipo.application.port.out.QueryInitialMarketPricePort;

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/local/LocalAccountPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/local/LocalAccountPersistenceAdapter.java
@@ -2,19 +2,21 @@ package com.alzzaipo.member.adapter.out.persistence.account.local;
 
 import com.alzzaipo.common.Email;
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
-import com.alzzaipo.member.application.port.out.account.local.*;
+import com.alzzaipo.member.application.port.out.account.local.ChangeLocalAccountEmail;
+import com.alzzaipo.member.application.port.out.account.local.ChangeLocalAccountPasswordPort;
+import com.alzzaipo.member.application.port.out.account.local.FindLocalAccountByAccountIdPort;
+import com.alzzaipo.member.application.port.out.account.local.FindLocalAccountByEmailPort;
+import com.alzzaipo.member.application.port.out.account.local.FindLocalAccountByMemberUidPort;
+import com.alzzaipo.member.application.port.out.account.local.RegisterLocalAccountPort;
 import com.alzzaipo.member.application.port.out.dto.SecureLocalAccount;
 import com.alzzaipo.member.domain.account.local.LocalAccountId;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Component
 @Transactional
@@ -55,8 +57,8 @@ public class LocalAccountPersistenceAdapter implements
 
     @Override
     public void registerLocalAccountPort(SecureLocalAccount secureLocalAccount) {
-        MemberJpaEntity memberJpaEntity = memberRepository.findByUid(secureLocalAccount.getMemberUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 엔티티 조회 실패"));
+        MemberJpaEntity memberJpaEntity
+            = memberRepository.findEntityById(secureLocalAccount.getMemberUID().get());
 
         LocalAccountJpaEntity localAccountJpaEntity = toJpaEntity(memberJpaEntity, secureLocalAccount);
 

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountPersistenceAdapterPort.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountPersistenceAdapterPort.java
@@ -37,8 +37,7 @@ public class SocialAccountPersistenceAdapterPort implements
 	@Override
 	public void registerSocialAccount(SocialAccount socialAccount) {
 		MemberJpaEntity memberJpaEntity =
-			memberRepository.findByUid(socialAccount.getMemberUID().get())
-				.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+			memberRepository.findEntityById(socialAccount.getMemberUID().get());
 
 		SocialAccountJpaEntity socialAccountJpaEntity = toJpaEntity(memberJpaEntity, socialAccount);
 		socialAccountRepository.save(socialAccountJpaEntity);

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountPersistenceAdapterPort.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountPersistenceAdapterPort.java
@@ -13,86 +13,86 @@ import com.alzzaipo.member.application.port.out.account.social.RegisterSocialAcc
 import com.alzzaipo.member.application.port.out.dto.FindSocialAccountCommand;
 import com.alzzaipo.member.application.port.out.member.FindMemberSocialAccountsPort;
 import com.alzzaipo.member.domain.account.social.SocialAccount;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class SocialAccountPersistenceAdapterPort implements
-        RegisterSocialAccountPort,
-        FindSocialAccountPort,
-        FindMemberSocialAccountsPort,
-        FindSocialAccountByLoginTypePort,
-        DeleteSocialAccountPort {
+	RegisterSocialAccountPort,
+	FindSocialAccountPort,
+	FindMemberSocialAccountsPort,
+	FindSocialAccountByLoginTypePort,
+	DeleteSocialAccountPort {
 
-    private final MemberRepository memberRepository;
-    private final SocialAccountRepository socialAccountRepository;
+	private final MemberRepository memberRepository;
+	private final SocialAccountRepository socialAccountRepository;
 
-    @Override
-    public void registerSocialAccount(SocialAccount socialAccount) {
-        MemberJpaEntity memberJpaEntity = memberRepository.findByUid(socialAccount.getMemberUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public void registerSocialAccount(SocialAccount socialAccount) {
+		MemberJpaEntity memberJpaEntity =
+			memberRepository.findByUid(socialAccount.getMemberUID().get())
+				.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
 
-        SocialAccountJpaEntity socialAccountJpaEntity = toJpaEntity(memberJpaEntity, socialAccount);
-        socialAccountRepository.save(socialAccountJpaEntity);
-    }
+		SocialAccountJpaEntity socialAccountJpaEntity = toJpaEntity(memberJpaEntity, socialAccount);
+		socialAccountRepository.save(socialAccountJpaEntity);
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<SocialAccount> findSocialAccount(FindSocialAccountCommand command) {
-        LoginType loginType = command.getLoginType();
-        String email = command.getEmail().get();
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<SocialAccount> findSocialAccount(FindSocialAccountCommand command) {
+		LoginType loginType = command.getLoginType();
+		String email = command.getEmail().get();
 
-        return socialAccountRepository.findByLoginTypeAndEmail(loginType.name(), email)
-                .map(this::toDomainEntity);
-    }
+		return socialAccountRepository.findByLoginTypeAndEmail(loginType.name(), email)
+			.map(this::toDomainEntity);
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<SocialAccount> findMemberSocialAccounts(Uid memberUID) {
-        return socialAccountRepository.findByMemberUID(memberUID.get())
-                .stream()
-                .map(this::toDomainEntity)
-                .collect(Collectors.toList());
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public List<SocialAccount> findMemberSocialAccounts(Uid memberUID) {
+		return socialAccountRepository.findByMemberUID(memberUID.get())
+			.stream()
+			.map(this::toDomainEntity)
+			.collect(Collectors.toList());
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<SocialAccount> findSocialAccountByLoginType(Uid memberUID, LoginType loginType) {
-        return socialAccountRepository.findByLoginType(memberUID.get(), loginType.name())
-                .map(this::toDomainEntity);
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<SocialAccount> findSocialAccountByLoginType(Uid memberUID,
+		LoginType loginType) {
+		return socialAccountRepository.findByLoginType(memberUID.get(), loginType.name())
+			.map(this::toDomainEntity);
+	}
 
-    @Override
-    public void deleteSocialAccount(Uid memberUID, LoginType loginType) {
-        memberRepository.findByUid(memberUID.get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public void deleteSocialAccount(Uid memberUID, LoginType loginType) {
+		SocialAccountJpaEntity socialAccountJpaEntity =
+			socialAccountRepository.findByLoginType(memberUID.get(), loginType.name())
+				.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "계정 조회 실패"));
 
-        SocialAccountJpaEntity socialAccountJpaEntity = socialAccountRepository.findByLoginType(memberUID.get(), loginType.name())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "계정 조회 실패"));
+		socialAccountRepository.delete(socialAccountJpaEntity);
+	}
 
-        socialAccountRepository.delete(socialAccountJpaEntity);
-    }
+	private SocialAccountJpaEntity toJpaEntity(MemberJpaEntity memberJpaEntity,
+		SocialAccount socialAccount) {
+		return new SocialAccountJpaEntity(
+			socialAccount.getEmail().get(),
+			socialAccount.getLoginType().name(),
+			memberJpaEntity);
+	}
 
-    private SocialAccountJpaEntity toJpaEntity(MemberJpaEntity memberJpaEntity, SocialAccount socialAccount) {
-        return new SocialAccountJpaEntity(
-                socialAccount.getEmail().get(),
-                socialAccount.getLoginType().name(),
-                memberJpaEntity);
-    }
+	private SocialAccount toDomainEntity(SocialAccountJpaEntity socialAccountJpaEntity) {
+		Uid memberUID = new Uid(socialAccountJpaEntity.getMemberJpaEntity().getUid());
+		Email email = new Email(socialAccountJpaEntity.getEmail());
+		LoginType loginType = LoginType.valueOf(socialAccountJpaEntity.getLoginType());
 
-    private SocialAccount toDomainEntity(SocialAccountJpaEntity socialAccountJpaEntity) {
-        Uid memberUID = new Uid(socialAccountJpaEntity.getMemberJpaEntity().getUid());
-        Email email = new Email(socialAccountJpaEntity.getEmail());
-        LoginType loginType = LoginType.valueOf(socialAccountJpaEntity.getLoginType());
-
-        return new SocialAccount(memberUID, email, loginType);
-    }
+		return new SocialAccount(memberUID, email, loginType);
+	}
 }

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
@@ -8,53 +8,48 @@ import com.alzzaipo.member.application.port.out.member.RegisterMemberPort;
 import com.alzzaipo.member.application.port.out.member.WithdrawMemberPort;
 import com.alzzaipo.member.domain.member.Member;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class MemberPersistenceAdapter implements
-        RegisterMemberPort,
-        FindMemberPort,
-        ChangeMemberNicknamePort,
-        WithdrawMemberPort {
+	RegisterMemberPort,
+	FindMemberPort,
+	ChangeMemberNicknamePort,
+	WithdrawMemberPort {
 
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
 
-    @Override
-    public void registerMember(Member member) {
-        MemberJpaEntity memberJpaEntity = new MemberJpaEntity(member.getUid().get(), member.getNickname());
-        memberRepository.save(memberJpaEntity);
-    }
+	@Override
+	public void registerMember(Member member) {
+		MemberJpaEntity memberJpaEntity = new MemberJpaEntity(member.getUid().get(),
+			member.getNickname());
+		memberRepository.save(memberJpaEntity);
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<Member> findMember(Uid uid) {
-        return memberRepository.findByUid(uid.get())
-                .map(this::toDomainEntity);
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public Member findMember(Uid uid) throws CustomException {
+		MemberJpaEntity entity = memberRepository.findEntityById(uid.get());
+		return toDomainEntity(entity);
+	}
 
-    @Override
-    public void changeMemberNickname(Uid memberUID, String nickname) {
-        memberRepository.findByUid(memberUID.get())
-                .ifPresent(entity -> entity.changeNickname(nickname));
-    }
+	@Override
+	public void changeMemberNickname(Uid memberUID, String nickname) {
+		MemberJpaEntity entity = memberRepository.findEntityById(memberUID.get());
+		entity.changeNickname(nickname);
+	}
 
-    @Override
-    public void withdrawMember(Uid memberUID) {
-        MemberJpaEntity entity = memberRepository.findByUid(memberUID.get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public void withdrawMember(Uid memberUID) {
+		memberRepository.deleteById(memberUID.get());
+	}
 
-        memberRepository.delete(entity);
-    }
-
-    private Member toDomainEntity(MemberJpaEntity memberJpaEntity) {
-        return new Member(
-                new Uid(memberJpaEntity.getUid()),
-                memberJpaEntity.getNickname());
-    }
+	private Member toDomainEntity(MemberJpaEntity memberJpaEntity) {
+		return new Member(
+			new Uid(memberJpaEntity.getUid()),
+			memberJpaEntity.getNickname());
+	}
 }

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 @Component
 @Transactional
 @RequiredArgsConstructor
-public class MemberPersistenceAdapterPort implements
+public class MemberPersistenceAdapter implements
         RegisterMemberPort,
         FindMemberPort,
         ChangeMemberNicknamePort,

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
@@ -2,14 +2,8 @@ package com.alzzaipo.member.adapter.out.persistence.member;
 
 import com.alzzaipo.member.adapter.out.persistence.member.custom.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long>,
-    MemberRepositoryCustom {
+	MemberRepositoryCustom {
 
-    @Query("SELECT m FROM MemberJpaEntity m WHERE m.uid = :uid")
-    Optional<MemberJpaEntity> findByUid(@Param("uid") Long uid);
 }

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
@@ -1,12 +1,14 @@
 package com.alzzaipo.member.adapter.out.persistence.member;
 
+import com.alzzaipo.member.adapter.out.persistence.member.custom.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long> {
+public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long>,
+    MemberRepositoryCustom {
 
     @Query("SELECT m FROM MemberJpaEntity m WHERE m.uid = :uid")
     Optional<MemberJpaEntity> findByUid(@Param("uid") Long uid);

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
@@ -3,7 +3,6 @@ package com.alzzaipo.member.adapter.out.persistence.member;
 import com.alzzaipo.member.adapter.out.persistence.member.custom.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long>,
-	MemberRepositoryCustom {
+public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long>, MemberRepositoryCustom {
 
 }

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/custom/MemberRepositoryCustom.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/custom/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.alzzaipo.member.adapter.out.persistence.member.custom;
+
+import com.alzzaipo.common.exception.CustomException;
+import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
+
+public interface MemberRepositoryCustom {
+
+	MemberJpaEntity findEntityById(Long id) throws CustomException;
+}

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/custom/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/custom/MemberRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package com.alzzaipo.member.adapter.out.persistence.member.custom;
+
+import com.alzzaipo.common.exception.CustomException;
+import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+	private final EntityManager entityManager;
+
+	@Override
+	public MemberJpaEntity findEntityById(Long id) throws CustomException {
+		TypedQuery<MemberJpaEntity> query = entityManager.createQuery(
+			"SELECT m FROM MemberJpaEntity m WHERE m.uid = :id", MemberJpaEntity.class);
+		query.setParameter("id", id);
+
+		List<MemberJpaEntity> resultList = query.getResultList();
+
+		if (resultList.isEmpty()) {
+			throw new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패");
+		}
+		return resultList.get(0);
+	}
+}

--- a/src/main/java/com/alzzaipo/member/application/port/out/member/FindMemberPort.java
+++ b/src/main/java/com/alzzaipo/member/application/port/out/member/FindMemberPort.java
@@ -1,11 +1,10 @@
 package com.alzzaipo.member.application.port.out.member;
 
 import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.member.domain.member.Member;
-
-import java.util.Optional;
 
 public interface FindMemberPort {
 
-    Optional<Member> findMember(Uid uid);
+	Member findMember(Uid uid) throws CustomException;
 }

--- a/src/main/java/com/alzzaipo/member/application/service/member/FindMemberNicknameService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/member/FindMemberNicknameService.java
@@ -1,25 +1,21 @@
 package com.alzzaipo.member.application.service.member;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.member.application.port.in.member.FindMemberNicknameQuery;
 import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.member.domain.member.Member;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class FindMemberNicknameService implements FindMemberNicknameQuery {
 
-    private final FindMemberPort findMemberPort;
+	private final FindMemberPort findMemberPort;
 
-    @Override
-    public String findMemberNickname(Uid memberUID) {
-        Member member = findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-
-        return member.getNickname();
-    }
+	@Override
+	public String findMemberNickname(Uid memberUID) {
+		Member member = findMemberPort.findMember(memberUID);
+		return member.getNickname();
+	}
 }

--- a/src/main/java/com/alzzaipo/member/application/service/member/FindMemberProfileService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/member/FindMemberProfileService.java
@@ -30,8 +30,7 @@ public class FindMemberProfileService implements FindMemberProfileQuery {
 
     @Override
     public MemberProfile findMemberProfile(Uid memberUID, LoginType currentLoginType) {
-        Member member = findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+        Member member = findMemberPort.findMember(memberUID);
 
         Optional<SecureLocalAccount> optionalLocalAccount
                 = findLocalAccountByMemberUidPort.findLocalAccountByMemberUid(memberUID);

--- a/src/main/java/com/alzzaipo/member/application/service/member/UpdateMemberProfileService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/member/UpdateMemberProfileService.java
@@ -31,8 +31,7 @@ public class UpdateMemberProfileService implements UpdateMemberProfileUseCase {
     @Override
     @Transactional
     public void updateMemberProfile(UpdateMemberProfileCommand command) {
-        Member member = findMemberPort.findMember(command.getMemberUID())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+        Member member = findMemberPort.findMember(command.getMemberUID());
 
         changeMemberNickname(command);
 

--- a/src/main/java/com/alzzaipo/member/application/service/member/WithdrawMemberService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/member/WithdrawMemberService.java
@@ -1,26 +1,19 @@
 package com.alzzaipo.member.application.service.member;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.member.application.port.in.member.WithdrawMemberUseCase;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.member.application.port.out.member.WithdrawMemberPort;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class WithdrawMemberService implements WithdrawMemberUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final WithdrawMemberPort withdrawMemberPort;
+	private final WithdrawMemberPort withdrawMemberPort;
 
-    @Override
-    public void withdrawMember(Uid memberUID) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-
-        withdrawMemberPort.withdrawMember(memberUID);
-    }
+	@Override
+	public void withdrawMember(Uid memberUID) {
+		withdrawMemberPort.withdrawMember(memberUID);
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/adapter/out/persistence/criterion/NotificationCriterionPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/notification/adapter/out/persistence/criterion/NotificationCriterionPersistenceAdapter.java
@@ -32,8 +32,8 @@ public class NotificationCriterionPersistenceAdapter implements
 
     @Override
     public void registerNotificationCriterion(NotificationCriterion notificationCriterion) {
-        MemberJpaEntity memberJpaEntity = memberRepository.findByUid(notificationCriterion.getMemberUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+        MemberJpaEntity memberJpaEntity
+            = memberRepository.findEntityById(notificationCriterion.getMemberUID().get());
 
         NotificationCriterionJpaEntity entity = toJpaEntity(notificationCriterion, memberJpaEntity);
         notificationCriterionRepository.save(entity);

--- a/src/main/java/com/alzzaipo/notification/adapter/out/persistence/email/EmailNotificationPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/notification/adapter/out/persistence/email/EmailNotificationPersistenceAdapter.java
@@ -38,8 +38,8 @@ public class EmailNotificationPersistenceAdapter implements
 
     @Override
     public void registerEmailNotification(EmailNotification emailNotification) {
-        MemberJpaEntity memberJpaEntity = memberRepository.findByUid(emailNotification.getMemberUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+        MemberJpaEntity memberJpaEntity =
+            memberRepository.findEntityById(emailNotification.getMemberUID().get());
 
         EmailNotificationJpaEntity emailNotificationJpaEntity = toJpaEntity(emailNotification, memberJpaEntity);
         emailNotificationRepository.save(emailNotificationJpaEntity);

--- a/src/main/java/com/alzzaipo/notification/application/service/criterion/DeleteNotificationCriterionService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/criterion/DeleteNotificationCriterionService.java
@@ -2,7 +2,6 @@ package com.alzzaipo.notification.application.service.criterion;
 
 import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.dto.DeleteNotificationCriterionCommand;
 import com.alzzaipo.notification.application.port.in.criterion.DeleteNotificationCriterionUseCase;
 import com.alzzaipo.notification.application.port.out.criterion.DeleteNotificationCriterionPort;
@@ -16,29 +15,27 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteNotificationCriterionService implements DeleteNotificationCriterionUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final FindNotificationCriterionPort findNotificationCriterionPort;
-    private final DeleteNotificationCriterionPort deleteNotificationCriterionPort;
+	private final FindNotificationCriterionPort findNotificationCriterionPort;
+	private final DeleteNotificationCriterionPort deleteNotificationCriterionPort;
 
-    @Override
-    public void deleteNotificationCriterion(DeleteNotificationCriterionCommand command) {
-        validateMemberAndOwnership(command);
+	@Override
+	public void deleteNotificationCriterion(DeleteNotificationCriterionCommand command) {
+		validateMemberAndOwnership(command);
 
-        deleteNotificationCriterionPort.deleteNotificationCriterion(command.getNotificationCriterionUID());
-    }
+		deleteNotificationCriterionPort.deleteNotificationCriterion(
+			command.getNotificationCriterionUID());
+	}
 
-    private void validateMemberAndOwnership(DeleteNotificationCriterionCommand command) {
-        Uid memberUID = command.getMemberUID();
-        Uid notificationCriterionUID = command.getNotificationCriterionUID();
+	private void validateMemberAndOwnership(DeleteNotificationCriterionCommand command) {
+		Uid memberUID = command.getMemberUID();
+		Uid notificationCriterionUID = command.getNotificationCriterionUID();
 
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+		NotificationCriterion notificationCriterion =
+			findNotificationCriterionPort.findNotificationCriterion(notificationCriterionUID)
+				.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "알림 기준 조회 실패"));
 
-        NotificationCriterion notificationCriterion = findNotificationCriterionPort.findNotificationCriterion(notificationCriterionUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "알림 기준 조회 실패"));
-
-        if (!memberUID.equals(notificationCriterion.getMemberUID())) {
-            throw new CustomException(HttpStatus.UNAUTHORIZED, "오류: 접근 권한 없음");
-        }
-    }
+		if (!memberUID.equals(notificationCriterion.getMemberUID())) {
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "오류: 접근 권한 없음");
+		}
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/criterion/FindMemberNotificationCriteriaService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/criterion/FindMemberNotificationCriteriaService.java
@@ -1,41 +1,33 @@
 package com.alzzaipo.notification.application.service.criterion;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.dto.NotificationCriterionView;
 import com.alzzaipo.notification.application.port.in.criterion.FindMemberNotificationCriteriaQuery;
 import com.alzzaipo.notification.application.port.out.criterion.FindMemberNotificationCriteriaPort;
 import com.alzzaipo.notification.domain.criterion.NotificationCriterion;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class FindMemberNotificationCriteriaService implements FindMemberNotificationCriteriaQuery {
 
-    private final FindMemberNotificationCriteriaPort findMemberNotificationCriteriaPort;
-    private final FindMemberPort findMemberPort;
+	private final FindMemberNotificationCriteriaPort findMemberNotificationCriteriaPort;
 
-    @Override
-    public List<NotificationCriterionView> findMemberNotificationCriteria(Uid memberUID) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public List<NotificationCriterionView> findMemberNotificationCriteria(Uid memberUID) {
+		return findMemberNotificationCriteriaPort.findMemberNotificationCriteria(memberUID)
+			.stream()
+			.map(this::toViewModel)
+			.collect(Collectors.toList());
+	}
 
-        return findMemberNotificationCriteriaPort.findMemberNotificationCriteria(memberUID)
-                .stream()
-                .map(this::toViewModel)
-                .collect(Collectors.toList());
-    }
-
-    private NotificationCriterionView toViewModel(NotificationCriterion notificationCriterion) {
-        return new NotificationCriterionView(
-                notificationCriterion.getNotificationCriterionUID().get(),
-                notificationCriterion.getMinCompetitionRate(),
-                notificationCriterion.getMinLockupRate());
-    }
+	private NotificationCriterionView toViewModel(NotificationCriterion notificationCriterion) {
+		return new NotificationCriterionView(
+			notificationCriterion.getNotificationCriterionUID().get(),
+			notificationCriterion.getMinCompetitionRate(),
+			notificationCriterion.getMinLockupRate());
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/criterion/UpdateNotificationCriterionService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/criterion/UpdateNotificationCriterionService.java
@@ -2,7 +2,6 @@ package com.alzzaipo.notification.application.service.criterion;
 
 import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.dto.UpdateNotificationCriterionCommand;
 import com.alzzaipo.notification.application.port.in.criterion.UpdateNotificationCriterionUseCase;
 import com.alzzaipo.notification.application.port.out.criterion.FindNotificationCriterionPort;
@@ -16,29 +15,26 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UpdateNotificationCriterionService implements UpdateNotificationCriterionUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final FindNotificationCriterionPort findNotificationCriterionPort;
-    private final UpdateNotificationCriterionPort updateNotificationCriterionPort;
+	private final FindNotificationCriterionPort findNotificationCriterionPort;
+	private final UpdateNotificationCriterionPort updateNotificationCriterionPort;
 
-    @Override
-    public void updateNotificationCriterion(UpdateNotificationCriterionCommand command) {
-        validateMemberAndOwnership(command);
+	@Override
+	public void updateNotificationCriterion(UpdateNotificationCriterionCommand command) {
+		validateMemberAndOwnership(command);
 
-        updateNotificationCriterionPort.updateNotificationCriterion(command);
-    }
+		updateNotificationCriterionPort.updateNotificationCriterion(command);
+	}
 
-    private void validateMemberAndOwnership(UpdateNotificationCriterionCommand command) {
-        Uid memberUID = command.getMemberUID();
-        Uid notificationCriterionUID = command.getNotificationCriterionUID();
+	private void validateMemberAndOwnership(UpdateNotificationCriterionCommand command) {
+		Uid memberUID = command.getMemberUID();
+		Uid notificationCriterionUID = command.getNotificationCriterionUID();
 
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+		NotificationCriterion notificationCriterion = findNotificationCriterionPort.findNotificationCriterion(
+				notificationCriterionUID)
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "알림 기준 조회 실패"));
 
-        NotificationCriterion notificationCriterion = findNotificationCriterionPort.findNotificationCriterion(notificationCriterionUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "알림 기준 조회 실패"));
-
-        if (!memberUID.equals(notificationCriterion.getMemberUID())) {
-            throw new CustomException(HttpStatus.UNAUTHORIZED, "오류: 권한 없음");
-        }
-    }
+		if (!memberUID.equals(notificationCriterion.getMemberUID())) {
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "오류: 권한 없음");
+		}
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/email/FindEmailNotificationService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/email/FindEmailNotificationService.java
@@ -1,40 +1,29 @@
 package com.alzzaipo.notification.application.service.email;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.dto.EmailNotificationStatus;
 import com.alzzaipo.notification.application.port.in.email.FindEmailNotificationStatusQuery;
 import com.alzzaipo.notification.application.port.out.email.FindEmailNotificationPort;
 import com.alzzaipo.notification.domain.email.EmailNotification;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
-
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class FindEmailNotificationService implements FindEmailNotificationStatusQuery {
 
-    private final FindMemberPort findMemberPort;
-    private final FindEmailNotificationPort findEmailNotificationPort;
+	private final FindEmailNotificationPort findEmailNotificationPort;
 
-    @Override
-    public EmailNotificationStatus findEmailNotificationStatus(Uid memberUID) {
-        validateMember(memberUID);
+	@Override
+	public EmailNotificationStatus findEmailNotificationStatus(Uid memberUID) {
+		Optional<EmailNotification> emailNotification =
+			findEmailNotificationPort.findEmailNotification(memberUID);
 
-        Optional<EmailNotification> emailNotification = findEmailNotificationPort.findEmailNotification(memberUID);
+		boolean subscriptionStatus = emailNotification.isPresent();
+		String email = emailNotification.map(e -> e.getEmail().get()).orElse(null);
 
-        boolean subscriptionStatus = emailNotification.isPresent();
-        String email = emailNotification.map(e -> e.getEmail().get()).orElse(null);
-
-        return new EmailNotificationStatus(subscriptionStatus, email);
-    }
-
-    private void validateMember(Uid memberUID) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-    }
+		return new EmailNotificationStatus(subscriptionStatus, email);
+	}
 
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/email/UnsubscribeEmailNotificationService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/email/UnsubscribeEmailNotificationService.java
@@ -1,30 +1,19 @@
 package com.alzzaipo.notification.application.service.email;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.in.email.UnsubscribeEmailNotificationUseCase;
 import com.alzzaipo.notification.application.port.out.UnsubscribeEmailNotificationPort;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class UnsubscribeEmailNotificationService implements UnsubscribeEmailNotificationUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final UnsubscribeEmailNotificationPort unsubscribeEmailNotificationPort;
+	private final UnsubscribeEmailNotificationPort unsubscribeEmailNotificationPort;
 
-    @Override
-    public void unsubscribeEmailNotification(Uid memberUID) {
-        validateMember(memberUID);
-
-        unsubscribeEmailNotificationPort.unsubscribeEmailNotification(memberUID);
-    }
-
-    private void validateMember(Uid memberUID) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
-    }
+	@Override
+	public void unsubscribeEmailNotification(Uid memberUID) {
+		unsubscribeEmailNotificationPort.unsubscribeEmailNotification(memberUID);
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/email/UpdateEmailNotificationService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/email/UpdateEmailNotificationService.java
@@ -5,7 +5,6 @@ import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.email.application.port.out.CheckEmailVerifiedPort;
 import com.alzzaipo.email.application.port.out.DeleteOldEmailVerificationHistoryPort;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.notification.application.port.in.email.UpdateEmailNotificationUseCase;
 import com.alzzaipo.notification.application.port.out.email.FindEmailNotificationPort;
 import com.alzzaipo.notification.application.port.out.email.UpdateEmailNotificataionPort;
@@ -18,32 +17,28 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UpdateEmailNotificationService implements UpdateEmailNotificationUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final FindEmailNotificationPort findEmailNotificationPort;
-    private final CheckEmailVerifiedPort checkEmailVerifiedPort;
-    private final UpdateEmailNotificataionPort updateEmailNotificataionPort;
-    private final DeleteOldEmailVerificationHistoryPort deleteOldEmailVerificationHistoryPort;
+	private final FindEmailNotificationPort findEmailNotificationPort;
+	private final CheckEmailVerifiedPort checkEmailVerifiedPort;
+	private final UpdateEmailNotificataionPort updateEmailNotificataionPort;
+	private final DeleteOldEmailVerificationHistoryPort deleteOldEmailVerificationHistoryPort;
 
-    @Override
-    public void updateEmailNotification(Uid memberUID, Email newEmail) {
-        validateMemberAndEmail(memberUID, newEmail);
+	@Override
+	public void updateEmailNotification(Uid memberUID, Email newEmail) {
+		validateMemberAndEmail(memberUID, newEmail);
 
-        EmailNotification newEmailNotification = new EmailNotification(memberUID, newEmail);
+		EmailNotification newEmailNotification = new EmailNotification(memberUID, newEmail);
 
-        updateEmailNotificataionPort.updateEmailNotificataion(newEmailNotification);
+		updateEmailNotificataionPort.updateEmailNotificataion(newEmailNotification);
 
-        deleteOldEmailVerificationHistoryPort.deleteOldEmailVerificationHistory(newEmail);
-    }
+		deleteOldEmailVerificationHistoryPort.deleteOldEmailVerificationHistory(newEmail);
+	}
 
-    private void validateMemberAndEmail(Uid memberUID, Email newEmail) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	private void validateMemberAndEmail(Uid memberUID, Email newEmail) {
+		findEmailNotificationPort.findEmailNotification(memberUID)
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이메일 알림 내역 조회 실패"));
 
-        findEmailNotificationPort.findEmailNotification(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이메일 알림 내역 조회 실패"));
-
-        if (!checkEmailVerifiedPort.checkEmailVerified(newEmail)) {
-            throw new CustomException(HttpStatus.UNAUTHORIZED, "오류 : 이메일 미인증");
-        }
-    }
+		if (!checkEmailVerifiedPort.checkEmailVerified(newEmail)) {
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "오류 : 이메일 미인증");
+		}
+	}
 }

--- a/src/main/java/com/alzzaipo/notification/application/service/email/scheduled/SendEmailNotificationService.java
+++ b/src/main/java/com/alzzaipo/notification/application/service/email/scheduled/SendEmailNotificationService.java
@@ -1,6 +1,6 @@
 package com.alzzaipo.notification.application.service.email.scheduled;
 
-import com.alzzaipo.email.application.port.in.SendCustomEmail;
+import com.alzzaipo.email.application.port.out.SendCustomEmail;
 import com.alzzaipo.common.Email;
 import com.alzzaipo.ipo.application.port.out.FindNotListedIposPort;
 import com.alzzaipo.ipo.domain.Ipo;

--- a/src/main/java/com/alzzaipo/portfolio/adapter/out/persistence/PortfolioPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/portfolio/adapter/out/persistence/PortfolioPersistenceAdapter.java
@@ -6,115 +6,119 @@ import com.alzzaipo.ipo.adapter.out.persistence.IpoJpaEntity;
 import com.alzzaipo.ipo.adapter.out.persistence.IpoRepository;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
-import com.alzzaipo.portfolio.application.out.*;
+import com.alzzaipo.portfolio.application.out.DeletePortfolioPort;
+import com.alzzaipo.portfolio.application.out.FindMemberPortfoliosPort;
+import com.alzzaipo.portfolio.application.out.FindPortfolioPort;
+import com.alzzaipo.portfolio.application.out.RegisterPortfolioPort;
+import com.alzzaipo.portfolio.application.out.UpdatePortfolioPort;
 import com.alzzaipo.portfolio.domain.Portfolio;
 import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class PortfolioPersistenceAdapter implements
-        RegisterPortfolioPort,
-        FindMemberPortfoliosPort,
-        FindPortfolioPort,
-        UpdatePortfolioPort,
-        DeletePortfolioPort {
+	RegisterPortfolioPort,
+	FindMemberPortfoliosPort,
+	FindPortfolioPort,
+	UpdatePortfolioPort,
+	DeletePortfolioPort {
 
-    private final PortfolioRepository portfolioRepository;
-    private final IpoRepository ipoRepository;
-    private final MemberRepository memberRepository;
-    private final EntityManager entityManager;
+	private final PortfolioRepository portfolioRepository;
+	private final IpoRepository ipoRepository;
+	private final MemberRepository memberRepository;
+	private final EntityManager entityManager;
 
-    @Override
-    public void registerPortfolio(Portfolio portfolio) {
-        MemberJpaEntity memberJpaEntity = memberRepository.findByUid(portfolio.getMemberUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public void registerPortfolio(Portfolio portfolio) {
+		MemberJpaEntity memberJpaEntity =
+			memberRepository.findEntityById(portfolio.getMemberUID().get());
 
-        IpoJpaEntity ipoJpaEntity = ipoRepository.findByStockCode(portfolio.getStockCode())
-                .orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "공모주 조회 실패"));
+		IpoJpaEntity ipoJpaEntity = ipoRepository.findByStockCode(portfolio.getStockCode())
+			.orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "공모주 조회 실패"));
 
-        PortfolioJpaEntity portfolioJpaEntity = toJpaEntity(
-                memberJpaEntity,
-                ipoJpaEntity,
-                portfolio);
+		PortfolioJpaEntity portfolioJpaEntity = toJpaEntity(
+			memberJpaEntity,
+			ipoJpaEntity,
+			portfolio);
 
-        portfolioRepository.save(portfolioJpaEntity);
-    }
+		portfolioRepository.save(portfolioJpaEntity);
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<Portfolio> findMemberPortfolios(Uid memberUID) {
-        return portfolioRepository.findByMemberUID(memberUID.get())
-                .stream()
-                .map(this::toDomainEntity)
-                .collect(Collectors.toList());
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public List<Portfolio> findMemberPortfolios(Uid memberUID) {
+		return portfolioRepository.findByMemberUID(memberUID.get())
+			.stream()
+			.map(this::toDomainEntity)
+			.collect(Collectors.toList());
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<Portfolio> findPortfolio(Uid portfolioUID) {
-        return portfolioRepository.findByPortfolioUID(portfolioUID.get())
-                .map(this::toDomainEntity);
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<Portfolio> findPortfolio(Uid portfolioUID) {
+		return portfolioRepository.findByPortfolioUID(portfolioUID.get())
+			.map(this::toDomainEntity);
+	}
 
-    @Override
-    public void updatePortfolio(Portfolio portfolio) {
-        PortfolioJpaEntity oldEntity = portfolioRepository.findByPortfolioUID(portfolio.getPortfolioUID().get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "포트폴리오 조회 실패"));
+	@Override
+	public void updatePortfolio(Portfolio portfolio) {
+		PortfolioJpaEntity oldEntity = portfolioRepository.findByPortfolioUID(
+				portfolio.getPortfolioUID().get())
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "포트폴리오 조회 실패"));
 
-        IpoJpaEntity newIpoJpaEntity = ipoRepository.findByStockCode(portfolio.getStockCode())
-                .orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "공모주 조회 실패"));
+		IpoJpaEntity newIpoJpaEntity = ipoRepository.findByStockCode(portfolio.getStockCode())
+			.orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "공모주 조회 실패"));
 
-        PortfolioJpaEntity newEntity = toJpaEntity(
-                oldEntity.getMemberJpaEntity(),
-                newIpoJpaEntity,
-                portfolio);
+		PortfolioJpaEntity newEntity = toJpaEntity(
+			oldEntity.getMemberJpaEntity(),
+			newIpoJpaEntity,
+			portfolio);
 
-        newEntity.setPortfolioUID(oldEntity.getPortfolioUID());
+		newEntity.setPortfolioUID(oldEntity.getPortfolioUID());
 
-        entityManager.merge(newEntity);
-    }
+		entityManager.merge(newEntity);
+	}
 
-    @Override
-    public void deletePortfolio(Uid portfolioUID) {
-        PortfolioJpaEntity entity = portfolioRepository.findByPortfolioUID(portfolioUID.get())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "포트폴리오 조회 실패"));
+	@Override
+	public void deletePortfolio(Uid portfolioUID) {
+		PortfolioJpaEntity entity = portfolioRepository.findByPortfolioUID(portfolioUID.get())
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "포트폴리오 조회 실패"));
 
-        portfolioRepository.delete(entity);
-    }
+		portfolioRepository.delete(entity);
+	}
 
-    private PortfolioJpaEntity toJpaEntity(MemberJpaEntity memberJpaEntity,
-                                           IpoJpaEntity ipoJpaEntity,
-                                           Portfolio portfolio) {
-        return new PortfolioJpaEntity(
-                portfolio.getPortfolioUID().get(),
-                portfolio.getSharesCnt(),
-                portfolio.getProfit(),
-                portfolio.getProfitRate(),
-                portfolio.getAgents(),
-                portfolio.getMemo(),
-                memberJpaEntity,
-                ipoJpaEntity);
-    }
+	private PortfolioJpaEntity toJpaEntity(MemberJpaEntity memberJpaEntity,
+		IpoJpaEntity ipoJpaEntity,
+		Portfolio portfolio) {
+		return new PortfolioJpaEntity(
+			portfolio.getPortfolioUID().get(),
+			portfolio.getSharesCnt(),
+			portfolio.getProfit(),
+			portfolio.getProfitRate(),
+			portfolio.getAgents(),
+			portfolio.getMemo(),
+			memberJpaEntity,
+			ipoJpaEntity);
+	}
 
-    private Portfolio toDomainEntity(PortfolioJpaEntity portfolioJpaEntity) {
-        return new Portfolio(
-                new Uid(portfolioJpaEntity.getPortfolioUID()),
-                new Uid(portfolioJpaEntity.getMemberJpaEntity().getUid()),
-                portfolioJpaEntity.getIpoJpaEntity().getStockName(),
-                portfolioJpaEntity.getIpoJpaEntity().getStockCode(),
-                portfolioJpaEntity.getSharesCnt(),
-                portfolioJpaEntity.getProfit(),
-                portfolioJpaEntity.getProfitRate(),
-                portfolioJpaEntity.getAgents(),
-                portfolioJpaEntity.getMemo());
-    }
+	private Portfolio toDomainEntity(PortfolioJpaEntity portfolioJpaEntity) {
+		return new Portfolio(
+			new Uid(portfolioJpaEntity.getPortfolioUID()),
+			new Uid(portfolioJpaEntity.getMemberJpaEntity().getUid()),
+			portfolioJpaEntity.getIpoJpaEntity().getStockName(),
+			portfolioJpaEntity.getIpoJpaEntity().getStockCode(),
+			portfolioJpaEntity.getSharesCnt(),
+			portfolioJpaEntity.getProfit(),
+			portfolioJpaEntity.getProfitRate(),
+			portfolioJpaEntity.getAgents(),
+			portfolioJpaEntity.getMemo());
+	}
 }

--- a/src/main/java/com/alzzaipo/portfolio/application/service/FindMemberPortfoliosService.java
+++ b/src/main/java/com/alzzaipo/portfolio/application/service/FindMemberPortfoliosService.java
@@ -1,49 +1,41 @@
 package com.alzzaipo.portfolio.application.service;
 
 import com.alzzaipo.common.Uid;
-import com.alzzaipo.common.exception.CustomException;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.portfolio.application.dto.MemberPortfolioSummary;
 import com.alzzaipo.portfolio.application.dto.PortfolioView;
 import com.alzzaipo.portfolio.application.in.FindMemberPortfoliosQuery;
 import com.alzzaipo.portfolio.application.out.FindMemberPortfoliosPort;
 import com.alzzaipo.portfolio.domain.Portfolio;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class FindMemberPortfoliosService implements FindMemberPortfoliosQuery {
 
-    private final FindMemberPort findMemberPort;
-    private final FindMemberPortfoliosPort findMemberPortfoliosPort;
+	private final FindMemberPortfoliosPort findMemberPortfoliosPort;
 
-    @Override
-    public MemberPortfolioSummary findMemberPortfolios(Uid memberUID) {
-        findMemberPort.findMember(memberUID)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public MemberPortfolioSummary findMemberPortfolios(Uid memberUID) {
+		List<PortfolioView> portfolioList = findMemberPortfoliosPort.findMemberPortfolios(memberUID)
+			.stream()
+			.map(this::toViewModel)
+			.collect(Collectors.toList());
 
-        List<PortfolioView> portfolioList = findMemberPortfoliosPort.findMemberPortfolios(memberUID)
-                .stream()
-                .map(this::toViewModel)
-                .collect(Collectors.toList());
+		return new MemberPortfolioSummary(portfolioList);
+	}
 
-        return new MemberPortfolioSummary(portfolioList);
-    }
-
-    public PortfolioView toViewModel(Portfolio portfolio) {
-        return new PortfolioView(
-                portfolio.getPortfolioUID().get(),
-                portfolio.getStockName(),
-                portfolio.getStockCode(),
-                portfolio.getSharesCnt(),
-                portfolio.getProfit(),
-                portfolio.getProfitRate(),
-                portfolio.getAgents(),
-                portfolio.getMemo());
-    }
+	public PortfolioView toViewModel(Portfolio portfolio) {
+		return new PortfolioView(
+			portfolio.getPortfolioUID().get(),
+			portfolio.getStockName(),
+			portfolio.getStockCode(),
+			portfolio.getSharesCnt(),
+			portfolio.getProfit(),
+			portfolio.getProfitRate(),
+			portfolio.getAgents(),
+			portfolio.getMemo());
+	}
 }

--- a/src/main/java/com/alzzaipo/portfolio/application/service/RegisterPortfolioService.java
+++ b/src/main/java/com/alzzaipo/portfolio/application/service/RegisterPortfolioService.java
@@ -3,7 +3,6 @@ package com.alzzaipo.portfolio.application.service;
 import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.ipo.application.port.out.FindIpoByStockCodePort;
 import com.alzzaipo.ipo.domain.Ipo;
-import com.alzzaipo.member.application.port.out.member.FindMemberPort;
 import com.alzzaipo.portfolio.application.dto.RegisterPortfolioCommand;
 import com.alzzaipo.portfolio.application.in.RegisterPortfolioUseCase;
 import com.alzzaipo.portfolio.application.out.RegisterPortfolioPort;
@@ -16,44 +15,40 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RegisterPortfolioService implements RegisterPortfolioUseCase {
 
-    private final FindMemberPort findMemberPort;
-    private final FindIpoByStockCodePort findIpoByStockCodePort;
-    private final RegisterPortfolioPort registerPortfolioPort;
+	private final FindIpoByStockCodePort findIpoByStockCodePort;
+	private final RegisterPortfolioPort registerPortfolioPort;
 
-    @Override
-    public void registerPortfolio(RegisterPortfolioCommand command) {
-        findMemberPort.findMember(command.getMemberUID())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+	@Override
+	public void registerPortfolio(RegisterPortfolioCommand command) {
+		Ipo ipo = findIpoByStockCodePort.findIpoByStockCodePort(command.getStockCode())
+			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "공모주 조회 실패"));
 
-        Ipo ipo = findIpoByStockCodePort.findIpoByStockCodePort(command.getStockCode())
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "공모주 조회 실패"));
+		Portfolio portfolio = createPortfolio(command, ipo);
 
-        Portfolio portfolio = createPortfolio(command, ipo);
+		registerPortfolioPort.registerPortfolio(portfolio);
+	}
 
-        registerPortfolioPort.registerPortfolio(portfolio);
-    }
+	private Portfolio createPortfolio(RegisterPortfolioCommand command, Ipo ipo) {
+		return Portfolio.create(
+			command.getMemberUID(),
+			ipo.getStockName(),
+			command.getStockCode(),
+			command.getSharesCnt(),
+			command.getProfit(),
+			calculateProfitRate(command, ipo),
+			command.getAgents(),
+			command.getMemo());
+	}
 
-    private Portfolio createPortfolio(RegisterPortfolioCommand command, Ipo ipo) {
-        return Portfolio.create(
-                command.getMemberUID(),
-                ipo.getStockName(),
-                command.getStockCode(),
-                command.getSharesCnt(),
-                command.getProfit(),
-                calculateProfitRate(command, ipo),
-                command.getAgents(),
-                command.getMemo());
-    }
+	private Long calculateProfitRate(RegisterPortfolioCommand command, Ipo ipo) {
+		Long profit = command.getProfit();
+		int sharesCnt = command.getSharesCnt();
+		int fixedOfferingPrice = ipo.getFixedOfferingPrice();
 
-    private Long calculateProfitRate(RegisterPortfolioCommand command, Ipo ipo) {
-        Long profit = command.getProfit();
-        int sharesCnt = command.getSharesCnt();
-        int fixedOfferingPrice = ipo.getFixedOfferingPrice();
-
-        if (sharesCnt > 0 && fixedOfferingPrice > 0) {
-            Long profitPerShare = profit / sharesCnt;
-            return (profitPerShare * 100 / fixedOfferingPrice);
-        }
-        return 0L;
-    }
+		if (sharesCnt > 0 && fixedOfferingPrice > 0) {
+			Long profitPerShare = profit / sharesCnt;
+			return (profitPerShare * 100 / fixedOfferingPrice);
+		}
+		return 0L;
+	}
 }


### PR DESCRIPTION
## 개요
- 커스텀 리포지토리 및 필터를 활용한 회원 엔티티 유효성 검증 코드 중복 제거

## 변경 사항
- 애플리케이션 곳곳에 분산된 회원 UID 검증 코드를 JWT 필터로 이동
  - 이를 통해, 코드 중복을 제거하고 토큰에 담긴 회원 UID의 유효성을 보장함 
- 커스텀 회원 조회 메서드를 활용한 코드 중복 제거
  - 기존 CrudRepository의 findById() 메서드는 Optional을 반환하여 언래핑 및 예외처리가 수반됨
  - 커스텀 회원 엔티티 조회 메서드를 정의하여 내부에서 예외를 처리하고 Optional 대신 영속성 엔티티를 반환하도록 구현

## 결과
- 애플리케이션 곳곳에 분산된 회원 엔티티 유효성 검증 코드 중복 제거 : 20개 -> 2개
### Before
<img width="812" alt="image" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/3ca33c0e-b58f-4fa6-a304-929f9489d05b">

### After
<img width="777" alt="image" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/c09e5af6-49fa-4aa7-9aad-95799bbdbf05">

