### PR TITLE
DataAccessException 예외처리 구현

### DIFF
--- a/src/main/java/com/alzzaipo/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/alzzaipo/common/exception/ExceptionControllerAdvice.java
@@ -73,7 +73,7 @@ public class ExceptionControllerAdvice {
     public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
         logger.error("Exception: {}", e.getMessage());
         ErrorResponse errorResponse = new ErrorResponse("예상치 못한 오류 발생");
-        return ResponseEntity.badRequest().body(errorResponse);
+        return ResponseEntity.internalServerError().body(errorResponse);
     }
 
     private String createValidationErrorMessage(BindingResult bindingResult) {

--- a/src/main/java/com/alzzaipo/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/alzzaipo/common/exception/ExceptionControllerAdvice.java
@@ -3,6 +3,7 @@ package com.alzzaipo.common.exception;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
@@ -47,12 +48,18 @@ public class ExceptionControllerAdvice {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         logger.error("MethodArgumentNotValidException : {}", e.getMessage());
         String errorMessage = createValidationErrorMessage(e.getBindingResult());
         ErrorResponse errorResponse = new ErrorResponse("입력 유효성 오류", errorMessage);
         return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ErrorResponse> handleDataAccessException(DataAccessException e) {
+        logger.error("DataAccessException : {}", e.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse("Internal Server Error");
+        return ResponseEntity.internalServerError().body(errorResponse);
     }
 
     @ExceptionHandler(CustomException.class)

--- a/src/main/java/com/alzzaipo/email/adapter/out/persistence/EmailVerificationHistoryRepository.java
+++ b/src/main/java/com/alzzaipo/email/adapter/out/persistence/EmailVerificationHistoryRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EmailVerificationHistoryRepository extends JpaRepository<EmailVerificationHistoryJpaEntity, Long> {
     @Query("SELECT e FROM EmailVerificationHistoryJpaEntity e WHERE e.email = :email")
     Optional<EmailVerificationHistoryJpaEntity> findByEmail(@Param("email") String email);

--- a/src/main/java/com/alzzaipo/ipo/adapter/out/persistence/IpoRepository.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/out/persistence/IpoRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface IpoRepository extends JpaRepository<IpoJpaEntity, Long> {
 
     @Query("SELECT i FROM IpoJpaEntity i WHERE i.stockCode = ?1")

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/local/LocalAccountRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/local/LocalAccountRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LocalAccountRepository extends JpaRepository<LocalAccountJpaEntity, Long> {
 
     @Query("SELECT l FROM LocalAccountJpaEntity l WHERE l.accountId = :accountId")

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/account/social/SocialAccountRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface SocialAccountRepository extends JpaRepository<SocialAccountJpaEntity, Long> {
 
     @Query("SELECT s FROM SocialAccountJpaEntity s WHERE s.loginType = :loginType AND s.email = :email")

--- a/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/persistence/member/MemberRepository.java
@@ -2,7 +2,9 @@ package com.alzzaipo.member.adapter.out.persistence.member;
 
 import com.alzzaipo.member.adapter.out.persistence.member.custom.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<MemberJpaEntity, Long>, MemberRepositoryCustom {
 
 }

--- a/src/main/java/com/alzzaipo/notification/adapter/out/persistence/criterion/NotificationCriterionRepository.java
+++ b/src/main/java/com/alzzaipo/notification/adapter/out/persistence/criterion/NotificationCriterionRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface NotificationCriterionRepository extends JpaRepository<NotificationCriterionJpaEntity, Long> {
 
     @Query("SELECT n FROM NotificationCriterionJpaEntity n WHERE n.memberJpaEntity.uid = :memberUID")

--- a/src/main/java/com/alzzaipo/notification/adapter/out/persistence/email/EmailNotificationRepository.java
+++ b/src/main/java/com/alzzaipo/notification/adapter/out/persistence/email/EmailNotificationRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EmailNotificationRepository extends JpaRepository<EmailNotificationJpaEntity, Long> {
 
     @Query("SELECT e FROM EmailNotificationJpaEntity e WHERE e.memberJpaEntity.uid = :memberUID")

--- a/src/main/java/com/alzzaipo/portfolio/adapter/out/persistence/PortfolioRepository.java
+++ b/src/main/java/com/alzzaipo/portfolio/adapter/out/persistence/PortfolioRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PortfolioRepository extends JpaRepository<PortfolioJpaEntity, Long> {
 
     @Query("SELECT p FROM PortfolioJpaEntity p WHERE p.memberJpaEntity.uid = :memberUID")


### PR DESCRIPTION
## 개요
- 기존 리포지토리에 @Repository 애너테이션 적용
- 예외처리 컨트롤러에 DataAccessException 예외처리 로직 추가

## 변경 사항
- 기존 리포지토리에 @Repository 애너테이션 적용
  - @Repository 애너테이션을 사용하면 스프링이 특정 JPA 구현체에 특화된 예외 타입을 DataAccessException으로 변환하여 데이터 접근 기술과 독립적인 에러처리 설계가 가능
-  예외처리 컨트롤러에 DataAccessException 예외처리 로직 추가
   - DB 관련 예외 발생 시, 특정 로그를 기록하고 상태코드 500으로 응답하도록 처리
- 최상위 예외 'Exception'에 해당하는 응답코드 변경 : 400 -> 500
  - 서버측에서 별도로 식별하여 처리되지 않은 기타 예외의 경우, 서버측 문제를 나타내는 500이 더 적절하다고 판단
## 참고
- https://velog.io/@qwerty1434/Repository의-스프링-예외-추상화-rjkzljqc