### PR TITLE
리프레시 토큰 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	implementation 'mysql:mysql-connector-java'
 

--- a/src/main/java/com/alzzaipo/common/Uid.java
+++ b/src/main/java/com/alzzaipo/common/Uid.java
@@ -17,6 +17,11 @@ public class Uid {
 		selfValidate();
 	}
 
+	public Uid(String uid) {
+		this.uid = Long.parseLong(uid);
+		selfValidate();
+	}
+
 	private void selfValidate() {
 		if (uid == null) {
 			throw new CustomException(HttpStatus.BAD_REQUEST, "UID 오류 : null");

--- a/src/main/java/com/alzzaipo/common/config/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/config/JwtFilter.java
@@ -6,8 +6,6 @@ import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.jwt.JwtUtil;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +42,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String token = resolveTokenFromAuthorizationHeader(request);
 		if (token == null) {
 			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.getWriter().write("Token Not Found");
+			response.getWriter().write("Missing Token");
 			filterChain.doFilter(request, response);
 			return;
 		}
@@ -58,19 +56,10 @@ public class JwtFilter extends OncePerRequestFilter {
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 
 			filterChain.doFilter(request, response);
-		} catch (ExpiredJwtException e) {
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.getWriter().write("Token has been expired");
-		} catch (SignatureException | BadCredentialsException e) {
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.getWriter().write("Invalid Token");
-		} catch (UsernameNotFoundException e) {
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.getWriter().write("User Not Found");
 		} catch (Exception e) {
 			logger.error(e.getMessage());
-			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			response.getWriter().write("Authentication Error");
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("Invalid Token");
 		}
 	}
 

--- a/src/main/java/com/alzzaipo/common/config/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/config/JwtFilter.java
@@ -1,8 +1,9 @@
-package com.alzzaipo.common.jwt;
+package com.alzzaipo.common.config;
 
 import com.alzzaipo.common.LoginType;
 import com.alzzaipo.common.MemberPrincipal;
 import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.jwt.JwtUtil;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberJpaEntity;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/alzzaipo/common/config/RedisConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.alzzaipo.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 				"/member/login",
 				"/ipo/**",
 				"/email/**",
-				"/oauth/kakao/login").permitAll()
+				"/login/**").permitAll()
 			.requestMatchers("/scraper").hasRole(Role.ADMIN.name())
 			.anyRequest().authenticated());
 

--- a/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.alzzaipo.common.config;
 
-import com.alzzaipo.common.jwt.JwtFilter;
 import com.alzzaipo.member.domain.member.Role;
 import com.alzzaipo.member.adapter.out.persistence.member.MemberRepository;
 import java.util.List;

--- a/src/main/java/com/alzzaipo/common/jwt/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtFilter.java
@@ -97,17 +97,15 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-		List<String> excludePath = Arrays.asList(
+		List<String> whitelist = Arrays.asList(
 			"/member/verify-account-id",
 			"/member/verify-email",
 			"/member/register",
-			"/member/login",
 			"/ipo",
 			"/email",
-			"/oauth/kakao/login");
+			"/login");
 
 		String path = request.getRequestURI();
-
-		return excludePath.stream().anyMatch(path::startsWith);
+		return whitelist.stream().anyMatch(path::startsWith);
 	}
 }

--- a/src/main/java/com/alzzaipo/common/jwt/JwtProperties.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtProperties.java
@@ -12,5 +12,6 @@ import org.springframework.stereotype.Component;
 public class JwtProperties {
 
 	private String secretKey;
-	private Long expirationTimeMillis;
+	private Long accessTokenExpirationTimeMillis;
+	private Long refreshTokenExpirationTimeMillis;
 }

--- a/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
@@ -22,17 +22,10 @@ public class JwtUtil {
 		JwtUtil.jwtProperties = jwtProperties;
 	}
 
-	public static String createToken(Uid memberUID, LoginType loginType) {
-		Claims claims = Jwts.claims();
-		claims.setSubject(memberUID.toString());
-		claims.put("loginType", loginType.name());
-
-		return Jwts.builder()
-			.setClaims(claims)
-			.setIssuedAt(new Date())
-			.setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpirationTimeMillis()))
-			.signWith(getSecretKey(), SignatureAlgorithm.HS256)
-			.compact();
+	public static TokenInfo createToken(Uid memberId, LoginType loginType) {
+		String accessToken = generateToken(memberId, loginType, jwtProperties.getAccessTokenExpirationTimeMillis());
+		String refreshToken = generateToken(memberId, loginType, jwtProperties.getRefreshTokenExpirationTimeMillis());
+		return new TokenInfo(accessToken, refreshToken);
 	}
 
 	public static Uid getMemberUID(String token) {
@@ -42,6 +35,28 @@ public class JwtUtil {
 
 	public static LoginType getLoginType(String token) {
 		return LoginType.valueOf((getClaims(token).get("loginType", String.class)));
+	}
+
+	public static boolean validate(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+		} catch(Exception e) {
+			return false;
+		}
+		return true;
+	}
+
+	private static String generateToken(Uid memberId, LoginType loginType, long expirationTimeMillis) {
+		Claims claims = Jwts.claims();
+		claims.setSubject(memberId.toString());
+		claims.put("loginType", loginType.name());
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + expirationTimeMillis))
+			.signWith(getSecretKey(), SignatureAlgorithm.HS256)
+			.compact();
 	}
 
 	private static Claims getClaims(String token) {

--- a/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
@@ -24,7 +24,7 @@ public class JwtUtil {
 
 	public static TokenInfo createToken(Uid memberId, LoginType loginType) {
 		String accessToken = generateToken(memberId, loginType, jwtProperties.getAccessTokenExpirationTimeMillis());
-		String refreshToken = generateToken(memberId, loginType, jwtProperties.getRefreshTokenExpirationTimeMillis());
+		String refreshToken = generateToken(null, loginType, jwtProperties.getRefreshTokenExpirationTimeMillis());
 		return new TokenInfo(accessToken, refreshToken);
 	}
 
@@ -48,8 +48,10 @@ public class JwtUtil {
 
 	private static String generateToken(Uid memberId, LoginType loginType, long expirationTimeMillis) {
 		Claims claims = Jwts.claims();
-		claims.setSubject(memberId.toString());
 		claims.put("loginType", loginType.name());
+		if(memberId != null) {
+			claims.setSubject(memberId.toString());
+		}
 
 		return Jwts.builder()
 			.setClaims(claims)

--- a/src/main/java/com/alzzaipo/common/jwt/TokenInfo.java
+++ b/src/main/java/com/alzzaipo/common/jwt/TokenInfo.java
@@ -1,0 +1,15 @@
+package com.alzzaipo.common.jwt;
+
+import lombok.Getter;
+
+@Getter
+public class TokenInfo {
+
+	private final String accessToken;
+	private final String RefreshToken;
+
+	public TokenInfo(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		RefreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/alzzaipo/member/adapter/in/web/LoginController.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/LoginController.java
@@ -1,0 +1,56 @@
+package com.alzzaipo.member.adapter.in.web;
+
+import com.alzzaipo.member.adapter.in.web.dto.LocalLoginWebRequest;
+import com.alzzaipo.member.adapter.in.web.dto.TokenResponse;
+import com.alzzaipo.member.application.port.in.account.local.LocalLoginUseCase;
+import com.alzzaipo.member.application.port.in.dto.AuthorizationCode;
+import com.alzzaipo.member.application.port.in.dto.LocalLoginCommand;
+import com.alzzaipo.member.application.port.in.dto.LoginResult;
+import com.alzzaipo.member.application.port.in.oauth.KakaoLoginUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/login")
+@RequiredArgsConstructor
+public class LoginController {
+
+	private final LocalLoginUseCase localLoginUseCase;
+	private final KakaoLoginUseCase kakaoLoginUseCase;
+
+	@PostMapping("/local")
+	public ResponseEntity<TokenResponse> login(@Valid @RequestBody LocalLoginWebRequest dto) {
+		LocalLoginCommand localLoginCommand = new LocalLoginCommand(
+			dto.getAccountId(),
+			dto.getAccountPassword());
+
+		LoginResult loginResult = localLoginUseCase.handleLocalLogin(localLoginCommand);
+
+		if (loginResult.isSuccess()) {
+			TokenResponse tokenResponse = TokenResponse.build(loginResult.getTokenInfo());
+			return ResponseEntity.ok(tokenResponse);
+		}
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+	}
+
+	@GetMapping("/kakao")
+	public ResponseEntity<TokenResponse> kakaoLogin(@RequestParam("code") String authCode) {
+		AuthorizationCode authorizationCode = new AuthorizationCode(authCode);
+
+		LoginResult loginResult = kakaoLoginUseCase.handleLogin(authorizationCode);
+
+		if (loginResult.isSuccess()) {
+			TokenResponse tokenResponse = TokenResponse.build(loginResult.getTokenInfo());
+			return ResponseEntity.ok(tokenResponse);
+		}
+		return ResponseEntity.badRequest().build();
+	}
+}

--- a/src/main/java/com/alzzaipo/member/adapter/in/web/LoginController.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/LoginController.java
@@ -1,7 +1,10 @@
 package com.alzzaipo.member.adapter.in.web;
 
+import com.alzzaipo.common.jwt.TokenInfo;
 import com.alzzaipo.member.adapter.in.web.dto.LocalLoginWebRequest;
+import com.alzzaipo.member.adapter.in.web.dto.RefreshTokenDto;
 import com.alzzaipo.member.adapter.in.web.dto.TokenResponse;
+import com.alzzaipo.member.application.port.in.RefreshTokenUseCase;
 import com.alzzaipo.member.application.port.in.account.local.LocalLoginUseCase;
 import com.alzzaipo.member.application.port.in.dto.AuthorizationCode;
 import com.alzzaipo.member.application.port.in.dto.LocalLoginCommand;
@@ -25,6 +28,7 @@ public class LoginController {
 
 	private final LocalLoginUseCase localLoginUseCase;
 	private final KakaoLoginUseCase kakaoLoginUseCase;
+	private final RefreshTokenUseCase refreshTokenUseCase;
 
 	@PostMapping("/local")
 	public ResponseEntity<TokenResponse> login(@Valid @RequestBody LocalLoginWebRequest dto) {
@@ -52,5 +56,12 @@ public class LoginController {
 			return ResponseEntity.ok(tokenResponse);
 		}
 		return ResponseEntity.badRequest().build();
+	}
+
+	@PostMapping("/refresh-token")
+	public ResponseEntity<TokenResponse> refreshToken(@Valid @RequestBody RefreshTokenDto dto) {
+		TokenInfo tokenInfo = refreshTokenUseCase.refresh(dto.getRefreshToken());
+		TokenResponse tokenResponse = TokenResponse.build(tokenInfo);
+		return ResponseEntity.ok(tokenResponse);
 	}
 }

--- a/src/main/java/com/alzzaipo/member/adapter/in/web/OAuthController.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/OAuthController.java
@@ -4,58 +4,36 @@ import com.alzzaipo.common.LoginType;
 import com.alzzaipo.common.MemberPrincipal;
 import com.alzzaipo.member.application.port.in.account.social.UnlinkSocialAccountUseCase;
 import com.alzzaipo.member.application.port.in.dto.AuthorizationCode;
-import com.alzzaipo.member.application.port.in.dto.LoginResult;
 import com.alzzaipo.member.application.port.in.dto.UnlinkSocialAccountCommand;
-import com.alzzaipo.member.application.port.in.oauth.KakaoLoginUseCase;
 import com.alzzaipo.member.application.port.in.oauth.LinkKakaoAccountUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class OAuthController {
 
-    private final KakaoLoginUseCase kakaoLoginUseCase;
-    private final LinkKakaoAccountUseCase linkKakaoAccountUseCase;
-    private final UnlinkSocialAccountUseCase unlinkSocialAccountUseCase;
+	private final LinkKakaoAccountUseCase linkKakaoAccountUseCase;
+	private final UnlinkSocialAccountUseCase unlinkSocialAccountUseCase;
 
-    @GetMapping("/kakao/login")
-    public ResponseEntity<String> kakaoLogin(@RequestParam("code") String authCode) {
-        AuthorizationCode authorizationCode = new AuthorizationCode(authCode);
+	@GetMapping("/kakao/link")
+	public ResponseEntity<String> kakaoLink(@AuthenticationPrincipal MemberPrincipal principal,
+		@RequestParam("code") String authCode) {
+		linkKakaoAccountUseCase.linkKakaoAccount(principal.getMemberUID(), new AuthorizationCode(authCode));
+		return ResponseEntity.ok().body("연동 완료");
+	}
 
-        LoginResult loginResult = kakaoLoginUseCase.handleLogin(authorizationCode);
-
-        if (loginResult.isSuccess()) {
-            String token = loginResult.getToken();
-
-            return ResponseEntity.ok()
-                    .header("Authorization", token)
-                    .body("로그인 성공");
-        }
-        return ResponseEntity.badRequest().body("로그인 실패");
-    }
-
-    @GetMapping("/kakao/link")
-    public ResponseEntity<String> kakaoLink(@AuthenticationPrincipal MemberPrincipal principal,
-                                            @RequestParam("code") String authCode) {
-        linkKakaoAccountUseCase.linkKakaoAccount(
-                principal.getMemberUID(),
-                new AuthorizationCode(authCode));
-
-        return ResponseEntity.ok().body("연동 완료");
-    }
-
-    @DeleteMapping("/kakao/unlink")
-    public ResponseEntity<String> kakaoUnlink(@AuthenticationPrincipal MemberPrincipal principal) {
-        UnlinkSocialAccountCommand command = new UnlinkSocialAccountCommand(
-                principal.getMemberUID(),
-                LoginType.KAKAO);
-
-        unlinkSocialAccountUseCase.unlinkSocialAccountUseCase(command);
-
-        return ResponseEntity.ok().body("해지 완료");
-    }
+	@DeleteMapping("/kakao/unlink")
+	public ResponseEntity<String> kakaoUnlink(@AuthenticationPrincipal MemberPrincipal principal) {
+		UnlinkSocialAccountCommand command = new UnlinkSocialAccountCommand(principal.getMemberUID(), LoginType.KAKAO);
+		unlinkSocialAccountUseCase.unlinkSocialAccountUseCase(command);
+		return ResponseEntity.ok().body("해지 완료");
+	}
 }

--- a/src/main/java/com/alzzaipo/member/adapter/in/web/dto/RefreshTokenDto.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/dto/RefreshTokenDto.java
@@ -1,0 +1,15 @@
+package com.alzzaipo.member.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RefreshTokenDto {
+
+	@NotBlank
+	private String refreshToken;
+}

--- a/src/main/java/com/alzzaipo/member/adapter/in/web/dto/TokenResponse.java
+++ b/src/main/java/com/alzzaipo/member/adapter/in/web/dto/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.alzzaipo.member.adapter.in.web.dto;
+
+import com.alzzaipo.common.jwt.TokenInfo;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+
+	private final String accessToken;
+	private final String refreshToken;
+
+	public TokenResponse(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+
+	public static TokenResponse build(TokenInfo tokenInfo) {
+		return new TokenResponse(tokenInfo.getAccessToken(), tokenInfo.getRefreshToken());
+	}
+}

--- a/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
@@ -1,19 +1,23 @@
 package com.alzzaipo.member.adapter.out.token;
 
 import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.common.jwt.JwtProperties;
 import com.alzzaipo.member.application.port.out.FindRefreshTokenPort;
+import com.alzzaipo.member.application.port.out.RenewRefreshTokenPort;
 import com.alzzaipo.member.application.port.out.SaveRefreshTokenPort;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort,
-	FindRefreshTokenPort {
+	FindRefreshTokenPort,
+	RenewRefreshTokenPort {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final JwtProperties jwtProperties;
@@ -31,5 +35,15 @@ public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort,
 			return Optional.of(new Uid(memberId));
 		}
 		return Optional.empty();
+	}
+
+	@Override
+	public void renew(String oldRefreshToken, String newRefreshToken) {
+		String memberId = redisTemplate.opsForValue().get(oldRefreshToken);
+		if (memberId == null) {
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token");
+		}
+		redisTemplate.delete(oldRefreshToken);
+		redisTemplate.opsForValue().set(newRefreshToken, memberId);
 	}
 }

--- a/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
@@ -1,0 +1,23 @@
+package com.alzzaipo.member.adapter.out.token;
+
+import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.jwt.JwtProperties;
+import com.alzzaipo.member.application.port.out.SaveRefreshTokenPort;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final JwtProperties jwtProperties;
+
+	@Override
+	public void save(String token, Uid memberId) {
+		Long expirationTimeMillis = jwtProperties.getRefreshTokenExpirationTimeMillis();
+		redisTemplate.opsForValue().set(token, memberId.toString(), expirationTimeMillis, TimeUnit.MILLISECONDS);
+	}
+}

--- a/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/member/adapter/out/token/RefreshTokenPersistenceAdapter.java
@@ -2,7 +2,9 @@ package com.alzzaipo.member.adapter.out.token;
 
 import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.jwt.JwtProperties;
+import com.alzzaipo.member.application.port.out.FindRefreshTokenPort;
 import com.alzzaipo.member.application.port.out.SaveRefreshTokenPort;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,7 +12,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort {
+public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort,
+	FindRefreshTokenPort {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final JwtProperties jwtProperties;
@@ -19,5 +22,14 @@ public class RefreshTokenPersistenceAdapter implements SaveRefreshTokenPort {
 	public void save(String token, Uid memberId) {
 		Long expirationTimeMillis = jwtProperties.getRefreshTokenExpirationTimeMillis();
 		redisTemplate.opsForValue().set(token, memberId.toString(), expirationTimeMillis, TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public Optional<Uid> find(String refreshToken) {
+		String memberId = redisTemplate.opsForValue().get(refreshToken);
+		if (memberId != null) {
+			return Optional.of(new Uid(memberId));
+		}
+		return Optional.empty();
 	}
 }

--- a/src/main/java/com/alzzaipo/member/application/port/in/RefreshTokenUseCase.java
+++ b/src/main/java/com/alzzaipo/member/application/port/in/RefreshTokenUseCase.java
@@ -1,0 +1,8 @@
+package com.alzzaipo.member.application.port.in;
+
+import com.alzzaipo.common.jwt.TokenInfo;
+
+public interface RefreshTokenUseCase {
+
+	TokenInfo refresh(String refreshToken);
+}

--- a/src/main/java/com/alzzaipo/member/application/port/in/dto/LoginResult.java
+++ b/src/main/java/com/alzzaipo/member/application/port/in/dto/LoginResult.java
@@ -1,19 +1,20 @@
 package com.alzzaipo.member.application.port.in.dto;
 
+import com.alzzaipo.common.jwt.TokenInfo;
 import lombok.Getter;
 
 @Getter
 public class LoginResult {
 
-    private final boolean success;
-    private final String token;
+	private final boolean success;
+	private final TokenInfo tokenInfo;
 
-    public LoginResult(boolean success, String token) {
-        this.success = success;
-        this.token = token;
-    }
+	public LoginResult(boolean success, TokenInfo tokenInfo) {
+		this.success = success;
+		this.tokenInfo = tokenInfo;
+	}
 
-    public static LoginResult getFailedResult() {
-        return new LoginResult(false, "");
-    }
+	public static LoginResult getFailedResult() {
+		return new LoginResult(false, null);
+	}
 }

--- a/src/main/java/com/alzzaipo/member/application/port/out/FindRefreshTokenPort.java
+++ b/src/main/java/com/alzzaipo/member/application/port/out/FindRefreshTokenPort.java
@@ -1,0 +1,9 @@
+package com.alzzaipo.member.application.port.out;
+
+import com.alzzaipo.common.Uid;
+import java.util.Optional;
+
+public interface FindRefreshTokenPort {
+
+	Optional<Uid> find(String refreshToken);
+}

--- a/src/main/java/com/alzzaipo/member/application/port/out/RenewRefreshTokenPort.java
+++ b/src/main/java/com/alzzaipo/member/application/port/out/RenewRefreshTokenPort.java
@@ -1,0 +1,6 @@
+package com.alzzaipo.member.application.port.out;
+
+public interface RenewRefreshTokenPort {
+
+	void renew(String oldRefreshToken, String newRefreshToken);
+}

--- a/src/main/java/com/alzzaipo/member/application/port/out/SaveRefreshTokenPort.java
+++ b/src/main/java/com/alzzaipo/member/application/port/out/SaveRefreshTokenPort.java
@@ -1,0 +1,8 @@
+package com.alzzaipo.member.application.port.out;
+
+import com.alzzaipo.common.Uid;
+
+public interface SaveRefreshTokenPort {
+
+	void save(String token, Uid memberId);
+}

--- a/src/main/java/com/alzzaipo/member/application/service/account/local/LocalLoginService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/account/local/LocalLoginService.java
@@ -1,45 +1,45 @@
 package com.alzzaipo.member.application.service.account.local;
 
 import com.alzzaipo.common.LoginType;
+import com.alzzaipo.common.Uid;
 import com.alzzaipo.common.jwt.JwtUtil;
+import com.alzzaipo.common.jwt.TokenInfo;
+import com.alzzaipo.member.application.port.in.account.local.LocalLoginUseCase;
 import com.alzzaipo.member.application.port.in.dto.LocalLoginCommand;
 import com.alzzaipo.member.application.port.in.dto.LoginResult;
-import com.alzzaipo.member.application.port.in.account.local.LocalLoginUseCase;
+import com.alzzaipo.member.application.port.out.SaveRefreshTokenPort;
 import com.alzzaipo.member.application.port.out.account.local.FindLocalAccountByAccountIdPort;
 import com.alzzaipo.member.application.port.out.dto.SecureLocalAccount;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class LocalLoginService implements LocalLoginUseCase {
 
-    private final PasswordEncoder passwordEncoder;
-    private final FindLocalAccountByAccountIdPort findLocalAccountByAccountIdPort;
+	private final PasswordEncoder passwordEncoder;
+	private final SaveRefreshTokenPort saveRefreshTokenPort;
+	private final FindLocalAccountByAccountIdPort findLocalAccountByAccountIdPort;
 
-    @Override
-    public LoginResult handleLocalLogin(LocalLoginCommand command) {
-        Optional<SecureLocalAccount> optionalSecureLocalAccount
-                = findLocalAccountByAccountIdPort.findLocalAccountByAccountId(command.getLocalAccountId());
+	@Override
+	public LoginResult handleLocalLogin(LocalLoginCommand command) {
+		Optional<SecureLocalAccount> optionalLocalAccount
+			= findLocalAccountByAccountIdPort.findLocalAccountByAccountId(command.getLocalAccountId());
 
-        if (optionalSecureLocalAccount.isPresent() && isPasswordValid(command, optionalSecureLocalAccount.get())) {
-            String token = createJwtToken(optionalSecureLocalAccount.get());
-            return new LoginResult(true, token);
-        }
+		if (optionalLocalAccount.isPresent() && isPasswordValid(command, optionalLocalAccount.get())) {
+			Uid memberId = optionalLocalAccount.get().getMemberUID();
+			TokenInfo tokenInfo = JwtUtil.createToken(memberId, LoginType.LOCAL);
+			saveRefreshTokenPort.save(tokenInfo.getRefreshToken(), memberId);
+			return new LoginResult(true, tokenInfo);
+		}
+		return LoginResult.getFailedResult();
+	}
 
-        return LoginResult.getFailedResult();
-    }
-
-    private boolean isPasswordValid(LocalLoginCommand command, SecureLocalAccount secureLocalAccount) {
-        String userProvidedPassword = command.getLocalAccountPassword().get();
-        String validEncryptedPassword = secureLocalAccount.getEncryptedAccountPassword();
-        return passwordEncoder.matches(userProvidedPassword, validEncryptedPassword);
-    }
-
-    private String createJwtToken(SecureLocalAccount secureLocalAccount) {
-        return JwtUtil.createToken(secureLocalAccount.getMemberUID(), LoginType.LOCAL);
-    }
+	private boolean isPasswordValid(LocalLoginCommand command, SecureLocalAccount secureLocalAccount) {
+		String userProvidedPassword = command.getLocalAccountPassword().get();
+		String validEncryptedPassword = secureLocalAccount.getEncryptedAccountPassword();
+		return passwordEncoder.matches(userProvidedPassword, validEncryptedPassword);
+	}
 }

--- a/src/main/java/com/alzzaipo/member/application/service/login/KakaoLoginService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/login/KakaoLoginService.java
@@ -1,4 +1,4 @@
-package com.alzzaipo.member.application.service.account.social;
+package com.alzzaipo.member.application.service.login;
 
 import com.alzzaipo.common.LoginType;
 import com.alzzaipo.common.jwt.JwtUtil;
@@ -57,14 +57,9 @@ public class KakaoLoginService implements KakaoLoginUseCase {
 
 	private SocialAccount registerSocialAccount(UserProfile userProfile) {
 		Member member = Member.create(userProfile.getNickname());
-
-		SocialAccount socialAccount = new SocialAccount(
-			member.getUid(),
-			userProfile.getEmail(),
-			KAKAO_LOGIN_TYPE);
-
 		registerMemberPort.registerMember(member);
 
+		SocialAccount socialAccount = new SocialAccount(member.getUid(), userProfile.getEmail(), KAKAO_LOGIN_TYPE);
 		registerSocialAccountPort.registerSocialAccount(socialAccount);
 
 		return socialAccount;

--- a/src/main/java/com/alzzaipo/member/application/service/login/LocalLoginService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/login/LocalLoginService.java
@@ -1,4 +1,4 @@
-package com.alzzaipo.member.application.service.account.local;
+package com.alzzaipo.member.application.service.login;
 
 import com.alzzaipo.common.LoginType;
 import com.alzzaipo.common.Uid;

--- a/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
@@ -1,0 +1,49 @@
+package com.alzzaipo.member.application.service.login;
+
+import com.alzzaipo.common.Uid;
+import com.alzzaipo.common.exception.CustomException;
+import com.alzzaipo.common.jwt.JwtUtil;
+import com.alzzaipo.common.jwt.TokenInfo;
+import com.alzzaipo.member.application.port.in.RefreshTokenUseCase;
+import com.alzzaipo.member.application.port.out.RenewRefreshTokenPort;
+import com.alzzaipo.member.application.port.out.FindRefreshTokenPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService implements RefreshTokenUseCase {
+
+	private final FindRefreshTokenPort findRefreshTokenPort;
+	private final RenewRefreshTokenPort renewRefreshTokenPort;
+
+	@Override
+	public TokenInfo refresh(String refreshToken) {
+		validateToken(refreshToken);
+
+		Uid memberId = findRefreshTokenPort.find(refreshToken)
+			.orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token"));
+
+		checkOwnership(memberId, JwtUtil.getMemberUID(refreshToken));
+
+		TokenInfo tokenInfo = JwtUtil.createToken(memberId, JwtUtil.getLoginType(refreshToken));
+		renewRefreshTokenPort.renew(refreshToken, tokenInfo.getRefreshToken());
+		return tokenInfo;
+	}
+
+	private void validateToken(String refreshToken) {
+		if (!JwtUtil.validate(refreshToken)) {
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token");
+		}
+	}
+
+	private void checkOwnership(Uid storedMemberId, Uid tokenMemberId) {
+		if(!storedMemberId.equals(tokenMemberId)) {
+			log.warn("Suspicious Refreshing Token Attempted : original {} / attempted: {}", storedMemberId, tokenMemberId);
+			throw new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token");
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
             enable: true
           connectiontimeout: 5000
           timeout: 30000
+  data:
+    redis:
+      host: ${redis.host}
+      port: ${redis.port}
+
 server:
   shutdown: graceful
 ---


### PR DESCRIPTION
## 개요
- Redis를 활용한 리프레시 토큰 구현

## 변동 사항
- Redis 의존성 설정
- 로그인 성공 시
  - 액세스 토큰과 리프레시 토큰을 생성하여 응답으로 전달
  - 리프레시 토큰을 회원 식별자와 함께 Redis DB에 저장
- 액세스 토큰 재발급 요청 시
  - 리프레시 토큰 검증 후 Redis DB를 조회하여 발급 내역이 있는지 확인
  - 리프레시 토큰 발급 내역이 확인되면 새로운 액세스 토큰과 리프레시 토큰을 생성한 후, 기존의 발급 내역을 삭제하고 새로운 발급 내역을 저장
- 리프레시 토큰을 통한 사용자 인증 방지
  - 액세스 토큰과 달리 리프레시 토큰의 경우 사용자 식별 정보인 sub 클레임을 제거