### PR TITLE
리프레시 토큰 재발급 오류 해결 및 보안 개선

### DIFF
--- a/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
+++ b/src/main/java/com/alzzaipo/common/jwt/JwtUtil.java
@@ -23,9 +23,19 @@ public class JwtUtil {
 	}
 
 	public static TokenInfo createToken(Uid memberId, LoginType loginType) {
-		String accessToken = generateToken(memberId, loginType, jwtProperties.getAccessTokenExpirationTimeMillis());
-		String refreshToken = generateToken(null, loginType, jwtProperties.getRefreshTokenExpirationTimeMillis());
+		String accessToken = generateAccessToken(memberId.get(), loginType);
+		String refreshToken = generateRefreshToken(loginType);
 		return new TokenInfo(accessToken, refreshToken);
+	}
+
+	public static TokenInfo refreshToken(Uid memberId, String refreshToken) {
+		Claims claims = getClaims(refreshToken);
+		LoginType loginType = LoginType.valueOf(claims.get("loginType", String.class));
+		Date refreshTokenExpirationDate = claims.getExpiration();
+
+		String accessToken = generateAccessToken(memberId.get(), loginType);
+		String newRefreshToken = generateRefreshToken(loginType, refreshTokenExpirationDate.getTime());
+		return new TokenInfo(accessToken, newRefreshToken);
 	}
 
 	public static Uid getMemberUID(String token) {
@@ -40,23 +50,38 @@ public class JwtUtil {
 	public static boolean validate(String token) {
 		try {
 			Jwts.parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
-		} catch(Exception e) {
+		} catch (Exception e) {
 			return false;
 		}
 		return true;
 	}
 
-	private static String generateToken(Uid memberId, LoginType loginType, long expirationTimeMillis) {
+	private static String generateAccessToken(Long memberId, LoginType loginType) {
+		return generateToken(memberId, loginType,
+			System.currentTimeMillis() + jwtProperties.getAccessTokenExpirationTimeMillis());
+	}
+
+	private static String generateRefreshToken(LoginType loginType) {
+		return generateToken(null, loginType,
+			System.currentTimeMillis() + jwtProperties.getRefreshTokenExpirationTimeMillis());
+	}
+
+	private static String generateRefreshToken(LoginType loginType, long expirationTimeMillis) {
+		return generateToken(null, loginType, expirationTimeMillis);
+	}
+
+	private static String generateToken(Long memberId, LoginType loginType, long expirationTimeMillis) {
 		Claims claims = Jwts.claims();
 		claims.put("loginType", loginType.name());
-		if(memberId != null) {
+
+		if (memberId != null) {
 			claims.setSubject(memberId.toString());
 		}
 
 		return Jwts.builder()
 			.setClaims(claims)
 			.setIssuedAt(new Date())
-			.setExpiration(new Date(System.currentTimeMillis() + expirationTimeMillis))
+			.setExpiration(new Date(expirationTimeMillis))
 			.signWith(getSecretKey(), SignatureAlgorithm.HS256)
 			.compact();
 	}

--- a/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
@@ -5,8 +5,8 @@ import com.alzzaipo.common.exception.CustomException;
 import com.alzzaipo.common.jwt.JwtUtil;
 import com.alzzaipo.common.jwt.TokenInfo;
 import com.alzzaipo.member.application.port.in.RefreshTokenUseCase;
-import com.alzzaipo.member.application.port.out.RenewRefreshTokenPort;
 import com.alzzaipo.member.application.port.out.FindRefreshTokenPort;
+import com.alzzaipo.member.application.port.out.RenewRefreshTokenPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -27,8 +27,6 @@ public class RefreshTokenService implements RefreshTokenUseCase {
 		Uid memberId = findRefreshTokenPort.find(refreshToken)
 			.orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token"));
 
-		checkOwnership(memberId, JwtUtil.getMemberUID(refreshToken));
-
 		TokenInfo tokenInfo = JwtUtil.createToken(memberId, JwtUtil.getLoginType(refreshToken));
 		renewRefreshTokenPort.renew(refreshToken, tokenInfo.getRefreshToken());
 		return tokenInfo;
@@ -36,13 +34,6 @@ public class RefreshTokenService implements RefreshTokenUseCase {
 
 	private void validateToken(String refreshToken) {
 		if (!JwtUtil.validate(refreshToken)) {
-			throw new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token");
-		}
-	}
-
-	private void checkOwnership(Uid storedMemberId, Uid tokenMemberId) {
-		if(!storedMemberId.equals(tokenMemberId)) {
-			log.warn("Suspicious Refreshing Token Attempted : original {} / attempted: {}", storedMemberId, tokenMemberId);
 			throw new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token");
 		}
 	}

--- a/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
+++ b/src/main/java/com/alzzaipo/member/application/service/login/RefreshTokenService.java
@@ -27,7 +27,7 @@ public class RefreshTokenService implements RefreshTokenUseCase {
 		Uid memberId = findRefreshTokenPort.find(refreshToken)
 			.orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token"));
 
-		TokenInfo tokenInfo = JwtUtil.createToken(memberId, JwtUtil.getLoginType(refreshToken));
+		TokenInfo tokenInfo = JwtUtil.refreshToken(memberId, refreshToken);
 		renewRefreshTokenPort.renew(refreshToken, tokenInfo.getRefreshToken());
 		return tokenInfo;
 	}


### PR DESCRIPTION
## 개요
- 정상적인 리프레시 토큰 재발급 요청이 거부되는 오류 해결
- 리프레시 토큰 재발급 시 만료시간은 유지되도록 변경
## 변경 사항
- 정상적인 리프레시 토큰 재발급 요청이 거부되는 오류 해결
  - 5f99920 커밋에서 리프레시 토큰의 sub 클레임을 제거한 변동 사항에 의해 checkOwnership() 메서드가 더 이상 유효하지 않아 정상 요청이 거부되는 문제가 발생 -> checkOwnership() 메서드를 제거하여 이를 해결
  - checkOwnership()은 전달받은 리프레시 토큰으로 Redis를 조회하여 저장된 회원 식별자와 sub 클레임의 회원 식별자가 일치하는지 검증하는 메서드인데, sub 클레임이 위조되었다면 토큰 값이 변경되어 식별자를 대조하지 않아도 DB 조회 단계에서 실패했을 것임. 즉, 애초부터 불필요한 로직이었음.
- 리프레시 토큰 재발급 시 만료시간은 유지되도록 변경
  - 기존에 리프레시 토큰 탈취 피해를 줄이기 위해 액세스 토큰 재발급 시 기존의 리프레시 토큰을 무효시키고 새로운 리프레시 토큰을 발급하도록 구현
  - 하지만 리프레시 토큰 재발급 시 만료시간을 갱신한다면 한번 탈취한 리프레시 토큰으로 액세스 토큰을 무한정 발급받을 수 있는 문제점이 존재
  - 이를 해결하기 위해 리프레시 토큰 재발급 시 만료시간은 그대로 유지되도록 변경