### PR TITLE
성능 개선 : 공모주 스크래핑, 상장 공모주 시초가 갱신

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'mysql:mysql-connector-java'
 
@@ -40,6 +41,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'com.github.f4b6a3:tsid-creator:5.2.5'
+
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/alzzaipo/common/config/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/config/JwtFilter.java
@@ -41,6 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		String token = resolveTokenFromAuthorizationHeader(request);
 		if (token == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			response.getWriter().write("Missing Token");
 			filterChain.doFilter(request, response);
 			return;

--- a/src/main/java/com/alzzaipo/common/config/JwtFilter.java
+++ b/src/main/java/com/alzzaipo/common/config/JwtFilter.java
@@ -41,7 +41,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		String token = resolveTokenFromAuthorizationHeader(request);
 		if (token == null) {
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			response.getWriter().write("Missing Token");
 			filterChain.doFilter(request, response);
 			return;
@@ -91,7 +90,8 @@ public class JwtFilter extends OncePerRequestFilter {
 			"/member/register",
 			"/ipo",
 			"/email",
-			"/login");
+			"/login",
+			"/actuator");
 
 		String path = request.getRequestURI();
 		return whitelist.stream().anyMatch(path::startsWith);

--- a/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
+++ b/src/main/java/com/alzzaipo/common/config/SecurityConfig.java
@@ -22,46 +22,47 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class SecurityConfig {
 
-	private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.csrf().disable()
-			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-			.cors().and()
-			.formLogin().disable()
-			.httpBasic().disable();
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+            .cors().and()
+            .formLogin().disable()
+            .httpBasic().disable();
 
-		http.addFilterBefore(new JwtFilter(memberRepository), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtFilter(memberRepository), UsernamePasswordAuthenticationFilter.class);
 
-		http.authorizeHttpRequests(requests -> requests
-			.requestMatchers("/member/register/**",
-				"/member/login",
-				"/ipo/**",
-				"/email/**",
-				"/login/**").permitAll()
-			.requestMatchers("/scraper").hasRole(Role.ADMIN.name())
-			.anyRequest().authenticated());
+        http.authorizeHttpRequests(requests -> requests
+            .requestMatchers("/member/register/**",
+                "/member/login",
+                "/ipo/**",
+                "/email/**",
+                "/login/**",
+                "/actuator/**").permitAll()
+            .requestMatchers("/scraper").hasRole(Role.ADMIN.name())
+            .anyRequest().authenticated());
 
-		return http.build();
-	}
+        return http.build();
+    }
 
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration config = new CorsConfiguration();
-		config.setAllowedOrigins(List.of("https://alzzaipo.com"));
-		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-		config.addAllowedHeader("*");
-		config.setAllowCredentials(true);
-		config.addExposedHeader("Authorization");
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("https://alzzaipo.com"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+        config.addExposedHeader("Authorization");
 
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", config);
-		return source;
-	}
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
 }

--- a/src/main/java/com/alzzaipo/common/config/TimedConfiguration.java
+++ b/src/main/java/com/alzzaipo/common/config/TimedConfiguration.java
@@ -1,0 +1,16 @@
+package com.alzzaipo.common.config;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimedConfiguration {
+
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
+
+}

--- a/src/main/java/com/alzzaipo/ipo/adapter/in/web/IpoScrapingController.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/in/web/IpoScrapingController.java
@@ -3,6 +3,7 @@ package com.alzzaipo.ipo.adapter.in.web;
 import com.alzzaipo.ipo.adapter.in.web.dto.ScrapeAndRegisterIposWebRequest;
 import com.alzzaipo.ipo.application.port.in.ScrapeAndRegisterIposUseCase;
 import com.alzzaipo.ipo.application.port.out.dto.ScrapeIposCommand;
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ public class IpoScrapingController {
 
 	private final ScrapeAndRegisterIposUseCase scrapeAndRegisterIposUseCase;
 
+	@Timed(value = "post_scraper")
 	@PostMapping("/scraper")
 	public ResponseEntity<String> scrapeAndRegisterIpos(@Valid @RequestBody ScrapeAndRegisterIposWebRequest dto) {
 		ScrapeIposCommand command = new ScrapeIposCommand(dto.getPageFrom(), dto.getPageTo());

--- a/src/main/java/com/alzzaipo/ipo/adapter/in/web/IpoScrapingController.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/in/web/IpoScrapingController.java
@@ -3,7 +3,6 @@ package com.alzzaipo.ipo.adapter.in.web;
 import com.alzzaipo.ipo.adapter.in.web.dto.ScrapeAndRegisterIposWebRequest;
 import com.alzzaipo.ipo.application.port.in.ScrapeAndRegisterIposUseCase;
 import com.alzzaipo.ipo.application.port.out.dto.ScrapeIposCommand;
-import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +16,6 @@ public class IpoScrapingController {
 
 	private final ScrapeAndRegisterIposUseCase scrapeAndRegisterIposUseCase;
 
-	@Timed(value = "post_scraper")
 	@PostMapping("/scraper")
 	public ResponseEntity<String> scrapeAndRegisterIpos(@Valid @RequestBody ScrapeAndRegisterIposWebRequest dto) {
 		ScrapeIposCommand command = new ScrapeIposCommand(dto.getPageFrom(), dto.getPageTo());

--- a/src/main/java/com/alzzaipo/ipo/adapter/out/persistence/IpoPersistenceAdapter.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/out/persistence/IpoPersistenceAdapter.java
@@ -6,7 +6,7 @@ import com.alzzaipo.ipo.application.port.out.FindAnalyzeIpoProfitRateTargetPort;
 import com.alzzaipo.ipo.application.port.out.FindIpoByStockCodePort;
 import com.alzzaipo.ipo.application.port.out.FindIpoListPort;
 import com.alzzaipo.ipo.application.port.out.FindNotListedIposPort;
-import com.alzzaipo.ipo.application.port.out.RegisterIpoPort;
+import com.alzzaipo.ipo.application.port.out.SaveIposPort;
 import com.alzzaipo.ipo.application.port.out.UpdateListedIpoPort;
 import com.alzzaipo.ipo.application.port.out.dto.CheckIpoRegisteredPort;
 import com.alzzaipo.ipo.application.port.out.dto.UpdateListedIpoCommand;
@@ -19,8 +19,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class IpoPersistenceAdapter implements
-    RegisterIpoPort,
+public class IpoPersistenceAdapter implements SaveIposPort,
     FindIpoByStockCodePort,
     FindIpoListPort,
     FindAnalyzeIpoProfitRateTargetPort,
@@ -31,8 +30,12 @@ public class IpoPersistenceAdapter implements
     private final IpoRepository ipoRepository;
 
     @Override
-    public void registerIpo(Ipo ipo) {
-        ipoRepository.save(IpoJpaEntity.build(ipo));
+    public void saveAll(List<Ipo> ipos) {
+        List<IpoJpaEntity> ipoJpaEntities = ipos.parallelStream()
+            .map(IpoJpaEntity::build)
+            .toList();
+
+        ipoRepository.saveAll(ipoJpaEntities);
     }
 
     @Override

--- a/src/main/java/com/alzzaipo/ipo/adapter/out/web/ScrapeIposFromIpo38Adapter.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/out/web/ScrapeIposFromIpo38Adapter.java
@@ -24,8 +24,7 @@ public class ScrapeIposFromIpo38Adapter implements ScrapeIposPort {
 
     @Override
     public List<ScrapedIpoDto> scrapeIpos(ScrapeIposCommand scrapeIposCommand) {
-        return IntStream
-            .rangeClosed(
+        return IntStream.rangeClosed(
                 scrapeIposCommand.getPageFrom(),
                 scrapeIposCommand.getPageTo()
             )
@@ -46,8 +45,7 @@ public class ScrapeIposFromIpo38Adapter implements ScrapeIposPort {
                 .get()
                 .select(selector);
 
-            ipoElements.stream()
-                .parallel()
+            ipoElements.parallelStream()
                 .forEach(ipoElement -> {
                     try {
                         ScrapedIpoDto ipoData = parseScrapedIpoDto(ipoElement);

--- a/src/main/java/com/alzzaipo/ipo/adapter/out/web/ScrapeIposFromIpo38Adapter.java
+++ b/src/main/java/com/alzzaipo/ipo/adapter/out/web/ScrapeIposFromIpo38Adapter.java
@@ -29,6 +29,7 @@ public class ScrapeIposFromIpo38Adapter implements ScrapeIposPort {
                 scrapeIposCommand.getPageFrom(),
                 scrapeIposCommand.getPageTo()
             )
+            .parallel()
             .mapToObj(this::scrapeIposFromPage)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
@@ -45,10 +46,17 @@ public class ScrapeIposFromIpo38Adapter implements ScrapeIposPort {
                 .get()
                 .select(selector);
 
-            for (Element ipoElement : ipoElements) {
-                ScrapedIpoDto ipoData = parseScrapedIpoDto(ipoElement);
-                result.add(ipoData);
-            }
+            ipoElements.stream()
+                .parallel()
+                .forEach(ipoElement -> {
+                    try {
+                        ScrapedIpoDto ipoData = parseScrapedIpoDto(ipoElement);
+                        result.add(ipoData);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
         } catch (Exception e) {
             log.error("Ipo Scraping Error : {}", e.getMessage());
         }

--- a/src/main/java/com/alzzaipo/ipo/application/port/out/RegisterIpoPort.java
+++ b/src/main/java/com/alzzaipo/ipo/application/port/out/RegisterIpoPort.java
@@ -1,8 +1,0 @@
-package com.alzzaipo.ipo.application.port.out;
-
-import com.alzzaipo.ipo.domain.Ipo;
-
-public interface RegisterIpoPort {
-
-    void registerIpo(Ipo ipo);
-}

--- a/src/main/java/com/alzzaipo/ipo/application/port/out/SaveIposPort.java
+++ b/src/main/java/com/alzzaipo/ipo/application/port/out/SaveIposPort.java
@@ -1,0 +1,10 @@
+package com.alzzaipo.ipo.application.port.out;
+
+import com.alzzaipo.ipo.domain.Ipo;
+import java.util.List;
+
+public interface SaveIposPort {
+
+    void saveAll(List<Ipo> ipos);
+
+}

--- a/src/main/java/com/alzzaipo/ipo/application/service/scheduled/ScrapeAndRegisterIpoScheduledService.java
+++ b/src/main/java/com/alzzaipo/ipo/application/service/scheduled/ScrapeAndRegisterIpoScheduledService.java
@@ -5,15 +5,17 @@ import com.alzzaipo.ipo.application.port.out.dto.ScrapeIposCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@Transactional
 @RequiredArgsConstructor
 public class ScrapeAndRegisterIpoScheduledService {
 
     private final ScrapeAndRegisterIposUseCase scrapeAndRegisterIposUseCase;
 
     @Scheduled(cron = "0 0 2 ? * MON-FRI")
-    private void scheduledTask() {
+    public void scheduledTask() {
         ScrapeIposCommand command = new ScrapeIposCommand(1, 1);
         scrapeAndRegisterIposUseCase.scrapeAndRegisterIposUseCase(command);
     }

--- a/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
+++ b/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
@@ -28,8 +28,7 @@ public class UpdateListedIpoInitialMarketPriceScheduledService {
         LocalDate currentDate = LocalDate.now();
 
         findNotListedIposPort.findNotListedIpos()
-            .stream()
-            .parallel()
+            .parallelStream()
             .filter(ipo -> currentDate.isAfter(ipo.getListedDate()))
             .forEach(this::queryInitialMarketPriceAndUpdate);
     }

--- a/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
+++ b/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
@@ -23,7 +23,7 @@ public class UpdateListedIpoInitialMarketPriceScheduledService {
     private final QueryInitialMarketPricePort queryInitialMarketPricePort;
     private final UpdateListedIpoPort updateListedIpoPort;
 
-    @Scheduled(cron = "* * 18 ? * MON-FRI")
+    @Scheduled(cron = "0 0 18 ? * MON-FRI")
     public void updateListedIpos() {
         LocalDate currentDate = LocalDate.now();
 

--- a/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
+++ b/src/main/java/com/alzzaipo/ipo/application/service/scheduled/UpdateListedIpoInitialMarketPriceScheduledService.java
@@ -29,6 +29,7 @@ public class UpdateListedIpoInitialMarketPriceScheduledService {
 
         findNotListedIposPort.findNotListedIpos()
             .stream()
+            .parallel()
             .filter(ipo -> currentDate.isAfter(ipo.getListedDate()))
             .forEach(this::queryInitialMarketPriceAndUpdate);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
 
 server:
   shutdown: graceful
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
 ---
 spring:
   config:


### PR DESCRIPTION
# 개요
- 공모주 스크래핑, 상장 공모주 시초가 갱신 작업 소요시간 단축
- close #88 

## 측정 기준
  - 로컬 환경
  - 공모주 스크래핑 : [IPO38_수요예측결과](http://www.ipo38.co.kr/ipo/index.htm?key=5) 페이지 40개 스크래핑 (총 데이터 : 800개)
  - 상장 공모주 시초가 갱신 : 스크래핑 후 등록된 754건의 데이터를 대상으로 [금융위원회_주식시세정보](https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15094808) API 호출

## 개선 결과
### 공모주 스크래핑 : 53.7s -> 7.67s (86% 단축)
<div>
<img width="350" alt="스크래핑 개선 전" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/7b3afc6c-ae36-4aa2-b9e8-9598a4bb88bb">
<img width="350" alt="스크래핑 개선 후" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/59a0a05c-06e9-492e-ab83-a2459945e72d">
</div>

### 상장 공모주 시초가 갱신 : 348s -> 14.2s (96% 단축)
<div>
<img width="350" alt="시초가 개선전" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/ba4de576-7fdf-4238-bdf6-77f44971bcba">
<img width="350" alt="시초가 개선후" src="https://github.com/alzzaipo/alzzaipo-Backend/assets/107951175/1de68f40-62f4-43ee-b701-292eb5666ece">
</div>

# 변경 사항
### 공모주 스크래핑
  - **개선 전**
    - 외부 반복자 사용 (for문)
    - 각 페이지를 순차적으로 처리 & 페이지에 존재하는 20건의 데이터를 순차적으로 처리
  - **개선 후**
    - 내부 반복자 사용 (스트림)
    - 병렬 스트림 적용 : 각 페이지 및 개별 데이터를 병렬로 처리
### 상장 공모주 시초가 갱신
  - 병렬 스트림 적용 : stream() -> parallelStream()